### PR TITLE
claude-code: centralize privacy settings in package

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,14 +100,6 @@ This repository uses GitHub Actions to automatically update all packages and fla
 - **Homepage**: https://github.com/charmbracelet/crush
 - **Usage**: `nix run .#crush -- --help`
 
-#### formatter
-
-- **Description**: One CLI to format the code tree
-- **Version**: unknown
-- **License**: MIT
-- **Homepage**: https://github.com/numtide/treefmt
-- **Usage**: `nix run .#formatter -- --help`
-
 #### gemini-cli
 
 - **Description**: AI agent that brings the power of Gemini directly into your terminal

--- a/packages/claude-code/package.nix
+++ b/packages/claude-code/package.nix
@@ -3,6 +3,7 @@
   buildNpmPackage,
   fetchzip,
   nodejs_20,
+  makeWrapper,
 }:
 
 buildNpmPackage rec {
@@ -18,6 +19,8 @@ buildNpmPackage rec {
 
   npmDepsHash = "sha256-yg4HKmEk7NiJScMl7K8cJAVIKOwmQfYFL0vuBh7Y7Q0=";
 
+  nativeBuildInputs = [ makeWrapper ];
+
   postPatch = ''
     cp ${./package-lock.json} package-lock.json
   '';
@@ -26,8 +29,15 @@ buildNpmPackage rec {
 
   AUTHORIZED = "1";
 
-  # Note: Environment variables like DISABLE_AUTOUPDATER and DEV are handled by claudebox
-  # which wraps this package. We don't set them here to avoid duplication.
+  # Disable auto-updates and telemetry by wrapping the binary
+  postInstall = ''
+    wrapProgram $out/bin/claude \
+      --set DISABLE_AUTOUPDATER 1 \
+      --set CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC 1 \
+      --set DISABLE_NON_ESSENTIAL_MODEL_CALLS 1 \
+      --set DISABLE_TELEMETRY 1 \
+      --unset DEV
+  '';
 
   passthru.updateScript = ./update.sh;
 

--- a/packages/claudebox/default.nix
+++ b/packages/claudebox/default.nix
@@ -61,11 +61,6 @@ pkgs.runCommand "claudebox"
 
     # Create claude wrapper that references the original
     makeWrapper ${perSystem.self.claude-code}/bin/claude $out/libexec/claudebox/claude \
-      --unset DEV \
-      --set CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC 1 \
-      --set DISABLE_AUTOUPDATER 1 \
-      --set DISABLE_NON_ESSENTIAL_MODEL_CALLS 1 \
-      --set DISABLE_TELEMETRY 1 \
       --set NODE_OPTIONS "--require=${./command-logger.js}" \
       --inherit-argv0
 


### PR DESCRIPTION
Move all privacy and telemetry environment variables from claudebox wrapper to the claude-code package itself. This ensures these settings are applied universally when using claude-code directly.