### PR TITLE
fix: test formatter

### DIFF
--- a/packages/formatter/default.nix
+++ b/packages/formatter/default.nix
@@ -41,7 +41,7 @@ let
 in
 formatter
 // {
-  meta = formatter.meta // {
+  passthru = formatter.passthru // {
     tests = {
       check = check;
     };


### PR DESCRIPTION
We were using the wrong prefix so the tests were not found by blueprint.
