### PR TITLE
crush: use buildGo124Module for Go 1.24+ omitzero semantics

### DIFF
--- a/packages/crush/package.nix
+++ b/packages/crush/package.nix
@@ -1,10 +1,9 @@
 {
   lib,
-  buildGoModule,
+  buildGo124Module,
   fetchFromGitHub,
 }:
-
-buildGoModule rec {
+buildGo124Module rec {
   pname = "crush";
   version = "0.6.2";
 


### PR DESCRIPTION
The anthropic library used by crush uses the omitzero semantics from the Go 1.24+ encoding/json release for request fields.

https://github.com/anthropics/anthropic-sdk-go/tree/68a1f2956930c10cad9c61a6fc368bf83b115b4b?tab=readme-ov-file#request-fields