### PR TITLE
fix: update amp's nodejs dependency to v22

### DIFF
--- a/packages/amp/package.nix
+++ b/packages/amp/package.nix
@@ -3,7 +3,7 @@
   buildNpmPackage,
   fetchurl,
   fetchNpmDeps,
-  nodejs_20,
+  nodejs_22,
   runCommand,
 }:
 
@@ -35,7 +35,7 @@ buildNpmPackage rec {
   # The package from npm is already built
   dontNpmBuild = true;
 
-  nodejs = nodejs_20;
+  nodejs = nodejs_22;
 
   passthru = {
     updateScript = ./update.sh;


### PR DESCRIPTION
Staying on version v20 breaks the Jetbrains plugin ([Reddit issue](https://www.reddit.com/r/AmpCode/comments/1no3u21/latest_version_breaks_intellij_idea_integration/)).

v21+ is an official requirement: https://ampcode.com/manual#jetbrains