### PR TITLE
amp: pass in ripgrep and disable update check

### DIFF
--- a/packages/amp/package.nix
+++ b/packages/amp/package.nix
@@ -4,6 +4,7 @@
   fetchurl,
   fetchNpmDeps,
   nodejs_22,
+  ripgrep,
   runCommand,
 }:
 
@@ -36,6 +37,12 @@ buildNpmPackage rec {
   dontNpmBuild = true;
 
   nodejs = nodejs_22;
+
+  postInstall = ''
+    wrapProgram $out/bin/amp \
+      --prefix PATH : ${lib.makeBinPath [ ripgrep ]} \
+      --set AMP_SKIP_UPDATE_CHECK 1
+  '';
 
   passthru = {
     updateScript = ./update.sh;


### PR DESCRIPTION
Hello from the amp team. Amp will automatically download ripgrep if not found on PATH. So lets skip that and let nix manage ripgrep. Additionally we show a message if amp is out of date / auto-update fails. It will fail if amp is living in the nix store, so skip that step.