### PR TITLE
Add llm package - CLI for interacting with LLMs

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -1,37 +1,30 @@
 name: Sync Fork with Upstream
-
 on:
   schedule:
     # Run daily at 2 AM UTC
     - cron: '0 2 * * *'
   workflow_dispatch: # Allow manual trigger
-
 jobs:
   sync:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout fork
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
-
       - name: Configure git
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-
       - name: Add upstream remote
         run: |
           git remote add upstream https://github.com/numtide/nix-ai-tools.git || true
           git fetch upstream
-
       - name: Sync main branch
         run: |
           git checkout main
           git merge upstream/main --no-edit
-
       - name: Push changes
         run: |
           git push origin main

--- a/README.md
+++ b/README.md
@@ -197,6 +197,15 @@ This repository uses GitHub Actions to automatically update all packages and fla
 - **Homepage**: https://github.com/build-with-groq/groq-code-cli
 - **Usage**: `nix run .#groq-code-cli -- --help`
 
+#### llm
+
+- **Description**: CLI tool and Python library for interacting with Large Language Models
+- **Version**: 0.27.1
+- **Source**: source
+- **License**: Apache-2.0
+- **Homepage**: https://llm.datasette.io/
+- **Usage**: `nix run .#llm -- --help`
+
 #### nanocoder
 
 - **Description**: A beautiful local-first coding agent running in your terminal - built by the community for the community ⚒

--- a/packages/llm/default.nix
+++ b/packages/llm/default.nix
@@ -1,0 +1,1 @@
+{ pkgs }: pkgs.callPackage ./package.nix { }

--- a/packages/llm/package.nix
+++ b/packages/llm/package.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  python3Packages,
+}:
+
+python3Packages.llm.overrideAttrs (oldAttrs: {
+  meta = oldAttrs.meta // {
+    description = "CLI tool and Python library for interacting with Large Language Models";
+    longDescription = ''
+      LLM is a CLI utility and Python library for interacting with OpenAI,
+      Anthropic's Claude, Google's Gemini, Meta's Llama and dozens of other
+      Large Language Models. It supports executing prompts from the terminal,
+      storing interactions in SQLite databases, generating embeddings, and
+      extracting structured data from text and images.
+    '';
+    homepage = "https://llm.datasette.io/";
+    changelog = "https://github.com/simonw/llm/releases";
+    license = lib.licenses.asl20;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    platforms = lib.platforms.all;
+    mainProgram = "llm";
+  };
+})


### PR DESCRIPTION
## Summary

Adds support for [llm](https://llm.datasette.io/) - a CLI tool and Python library for interacting with Large Language Models.

## What is llm?

`llm` is a versatile CLI tool that enables interaction with:
- OpenAI
- Anthropic's Claude  
- Google's Gemini
- Meta's Llama
- Dozens of other LLMs

## Features

- Execute prompts from the terminal
- Store interactions in SQLite databases
- Generate and store embeddings
- Extract structured data from text and images  
- Grant models tool execution capabilities
- Plugin system for extensibility

## Implementation

Since `llm` is already available in nixpkgs as `python3Packages.llm` (v0.27.1), this PR wraps it with enhanced metadata and makes it available as a standalone package in this flake.

### Package Structure (`packages/llm/`)

**package.nix**: Wraps nixpkgs python3Packages.llm
- Version 0.27.1 (latest in nixpkgs)
- Uses `overrideAttrs` to enhance metadata
- Cross-platform support: x86_64-linux, aarch64-linux, x86_64-darwin, aarch64-darwin
- Source-based (Python package)

**default.nix**: Standard callPackage wrapper

## Integration

The package integrates seamlessly with the repository's infrastructure:
- Auto-discovered by blueprint (no flake.nix changes needed)
- README auto-generated with package metadata
- Will be included in daily automated updates
- Builds from nixpkgs python3Packages

## Usage

Users can:

```bash
# Try without installing
nix run github:numtide/nix-ai-tools#llm -- --version

# Use with Anthropic
nix run github:numtide/nix-ai-tools#llm -- "explain nix flakes"

# Install plugins
nix run github:numtide/nix-ai-tools#llm -- install llm-anthropic
```

## Testing

Verified on x86_64-linux:
```bash
$ nix run .#llm -- --version
llm, version 0.27.1
```

## Related

- Upstream: https://github.com/simonw/llm
- Docs: https://llm.datasette.io/
- PyPI: https://pypi.org/project/llm/