### PR TITLE
droid: fix update script to use nix eval for hash extraction

### DIFF
--- a/packages/droid/package.nix
+++ b/packages/droid/package.nix
@@ -94,6 +94,10 @@ stdenv.mkDerivation {
     runHook postInstall
   '';
 
+  passthru = {
+    inherit sources rgSources;
+  };
+
   meta = with lib; {
     description = "Factory AI's Droid - AI-powered development agent for your terminal";
     homepage = "https://factory.ai";

--- a/packages/droid/update.sh
+++ b/packages/droid/update.sh
@@ -14,20 +14,42 @@ VERSION=$(curl -fsSL https://app.factory.ai/cli | grep -oP 'VER="\K[^"]+')
 
 echo "Found version: $VERSION"
 
-fetch_hash() {
-  local platform=$1
-  local arch=$2
-  local url="https://downloads.factory.ai/factory-cli/releases/${VERSION}/${platform}/${arch}/droid"
-  echo "Fetching hash for ${platform}/${arch}..." >&2
-  nix store prefetch-file --hash-type sha256 "$url" --json | jq -r .hash
-}
+fetch_and_update_hash() {
+  local section=$1      # "sources" or "rgSources"
+  local platform=$2     # "x86_64-linux", "aarch64-linux", or "aarch64-darwin"
+  local path_platform=$3
+  local arch=$4
+  local binary_name=$5
 
-fetch_rg_hash() {
-  local platform=$1
-  local arch=$2
-  local url="https://downloads.factory.ai/ripgrep/${platform}/${arch}/rg"
-  echo "Fetching rg hash for ${platform}/${arch}..." >&2
-  nix store prefetch-file --hash-type sha256 "$url" --json | jq -r .hash
+  # Build URL - ripgrep doesn't use version in path
+  local url
+  if [[ "$section" == "rgSources" ]]; then
+    url="https://downloads.factory.ai/ripgrep/${path_platform}/${arch}/${binary_name}"
+  else
+    url="https://downloads.factory.ai/factory-cli/releases/${VERSION}/${path_platform}/${arch}/${binary_name}"
+  fi
+
+  echo "Fetching hash for ${platform} ${binary_name}..." >&2
+  local new_hash
+  new_hash=$(nix store prefetch-file --hash-type sha256 "$url" --json | jq -r .hash)
+
+  if [ -z "$new_hash" ]; then
+    echo "Error: Failed to fetch new hash for ${section}.${platform}" >&2
+    return 1
+  fi
+
+  # Get the old hash using nix eval
+  local old_hash
+  old_hash=$(nix eval --raw "$ROOT#droid.passthru.${section}.${platform}.hash")
+
+  if [ -z "$old_hash" ]; then
+    echo "Error: Failed to get old hash for ${section}.${platform}" >&2
+    return 1
+  fi
+
+  echo "Replacing $old_hash with $new_hash for ${section}.${platform}" >&2
+  # Replace the specific old hash with the new hash
+  sed -i "s|${old_hash}|${new_hash}|" "$FILE"
 }
 
 echo "Updating droid to version $VERSION..."
@@ -36,19 +58,13 @@ echo "Updating droid to version $VERSION..."
 sed -i "s/version = \".*\"/version = \"$VERSION\"/" "$FILE"
 
 # Update droid binary hashes
-sed -i "/x86_64-linux = {/,/};/ s|hash = \"sha256-[^\"]*\"|hash = \"$(fetch_hash linux x64)\"|" "$FILE"
-sed -i "/aarch64-linux = {/,/};/ s|hash = \"sha256-[^\"]*\"|hash = \"$(fetch_hash linux arm64)\"|" "$FILE"
-sed -i "/aarch64-darwin = {/,/};/ s|hash = \"sha256-[^\"]*\"|hash = \"$(fetch_hash darwin arm64)\"|" "$FILE"
+fetch_and_update_hash "sources" "x86_64-linux" "linux" "x64" "droid"
+fetch_and_update_hash "sources" "aarch64-linux" "linux" "arm64" "droid"
+fetch_and_update_hash "sources" "aarch64-darwin" "darwin" "arm64" "droid"
 
 # Update ripgrep hashes
-sed -i "/rgSources = {/,/};/ {
-  /x86_64-linux = {/,/};/ s|hash = \"sha256-[^\"]*\"|hash = \"$(fetch_rg_hash linux x64)\"|
-}" "$FILE"
-sed -i "/rgSources = {/,/};/ {
-  /aarch64-linux = {/,/};/ s|hash = \"sha256-[^\"]*\"|hash = \"$(fetch_rg_hash linux arm64)\"|
-}" "$FILE"
-sed -i "/rgSources = {/,/};/ {
-  /aarch64-darwin = {/,/};/ s|hash = \"sha256-[^\"]*\"|hash = \"$(fetch_rg_hash darwin arm64)\"|
-}" "$FILE"
+fetch_and_update_hash "rgSources" "x86_64-linux" "linux" "x64" "rg"
+fetch_and_update_hash "rgSources" "aarch64-linux" "linux" "arm64" "rg"
+fetch_and_update_hash "rgSources" "aarch64-darwin" "darwin" "arm64" "rg"
 
 echo "Updated droid to $VERSION"


### PR DESCRIPTION

The previous script used sed range patterns that would match both the
sources and rgSources sections, causing ripgrep hashes to be overwritten
with droid binary hashes.

This refactor:
- Uses nix eval to extract old hashes from package.nix via passthru
- Replaces specific hash values instead of using regex patterns
- Uses a single unified function for all hash updates
- Validates that both old and new hashes are non-empty before replacement

Adds passthru to package.nix to expose sources and rgSources for nix eval.


