### PR TITLE
fix(opencode): update output hash of node_modules

### DIFF
--- a/packages/opencode/package.nix
+++ b/packages/opencode/package.nix
@@ -72,7 +72,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     # NOTE: Required else we get errors that our fixed-output derivation references store paths
     dontFixup = true;
 
-    outputHash = "sha256-C1gu8PyV7Byu84i7wM7oSwYQCyG2JG/Qe7g1Csarr0M=";
+    outputHash = "sha256-Q3008o4dEZdf/4ATOmOfJIJa7B+MeLVMWzfTLVDcWjg=";
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
   };


### PR DESCRIPTION
Bumping from [1.0.65 => 1.0.68](https://github.com/numtide/nix-ai-tools/pull/993/) may have added the following NPM packages:

@opencode-ai/script@workspace:packages/script
@opencode-ai/sdk@workspace:packages/sdk/js

Local build log:
```
source> 100 45.4M    0 45.4M    0     0  16.0M      0 --:--:--  0:00:02 --:--:-- 19.0M
source> unpacking source archive /nix/var/nix/builds/nix-47596-3332101435/download.tar.gz
resolved derivation: '/nix/store/f1b5rc7xjdhbfg7i4cyjz2qjhl1k4wc0-opencode-node_modules-1.0.68.drv' -> '/nix/store/mh61zdlyivf2k4q042ldfnk76wh4ncqn-opencode-node_modules-1.0.68.drv'
opencode-node_modules> building '/nix/store/mh61zdlyivf2k4q042ldfnk76wh4ncqn-opencode-node_modules-1.0.68.drv'
opencode-node_modules> Running phase: unpackPhase
opencode-node_modules> unpacking source archive /nix/store/1b4lp2xscvq5rwwdhqkqs38vkg38g3xx-source
opencode-node_modules> source root is source
opencode-node_modules> Running phase: patchPhase
opencode-node_modules> Running phase: updateAutotoolsGnuConfigScriptsPhase
opencode-node_modules> Running phase: buildPhase
opencode-node_modules> bun install v1.3.2 (b131639c)
opencode-node_modules> Resolving dependencies
opencode-node_modules> Resolved, downloaded and extracted [243]
opencode-node_modules>
opencode-node_modules> + @opencode-ai/script@workspace:packages/script
opencode-node_modules> + @opencode-ai/sdk@workspace:packages/sdk/js
opencode-node_modules>
opencode-node_modules> 963 packages installed [3.58s]
opencode-node_modules> Running phase: installPhase
error: hash mismatch in fixed-output derivation '/nix/store/mh61zdlyivf2k4q042ldfnk76wh4ncqn-opencode-node_modules-1.0.68.drv':
         specified: sha256-C1gu8PyV7Byu84i7wM7oSwYQCyG2JG/Qe7g1Csarr0M=
            got:    sha256-Q3008o4dEZdf/4ATOmOfJIJa7B+MeLVMWzfTLVDcWjg=
error: build of resolved derivation '/nix/store/mh61zdlyivf2k4q042ldfnk76wh4ncqn-opencode-node_modules-1.0.68.drv' failed
```