### PR TITLE
antigravity: init at 1.11.3-6583016683339776

### DIFF
--- a/packages/antigravity/default.nix
+++ b/packages/antigravity/default.nix
@@ -1,0 +1,5 @@
+{
+  pkgs,
+  ...
+}:
+pkgs.callPackage ./package.nix { }

--- a/packages/antigravity/package.nix
+++ b/packages/antigravity/package.nix
@@ -1,0 +1,86 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  undmg,
+  autoPatchelfHook,
+  gcc,
+}:
+
+let
+  version = "1.11.3-6583016683339776";
+
+  sources = {
+    x86_64-linux = {
+      url = "https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/${version}/linux-x64/Antigravity.tar.gz";
+      hash = "sha256-Al2lEvl5mnFU4sx1vAkIIBOCwazy6DePnaI1y4SlYVs=";
+    };
+    x86_64-darwin = {
+      url = "https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/${version}/darwin-x64/Antigravity.dmg";
+      hash = lib.fakeHash;
+    };
+    aarch64-darwin = {
+      url = "https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/${version}/darwin-arm/Antigravity.dmg";
+      hash = lib.fakeHash;
+    };
+  };
+
+  source =
+    sources.${stdenv.hostPlatform.system}
+      or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+in
+stdenv.mkDerivation rec {
+  pname = "antigravity";
+  inherit version;
+
+  src = fetchurl source;
+
+  nativeBuildInputs =
+    lib.optionals stdenv.hostPlatform.isDarwin [
+      undmg
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      autoPatchelfHook
+    ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    gcc.cc.lib
+  ];
+
+  sourceRoot = ".";
+
+  installPhase =
+    if stdenv.hostPlatform.isDarwin then
+      ''
+        runHook preInstall
+
+        mkdir -p $out/Applications
+        cp -r Antigravity.app $out/Applications/
+
+        runHook postInstall
+      ''
+    else
+      ''
+        runHook preInstall
+
+        mkdir -p $out/bin
+        cp -r Antigravity/bin/antigravity $out/bin/
+        chmod +x $out/bin/antigravity
+
+        runHook postInstall
+      '';
+
+  meta = with lib; {
+    description = "Antigravity application";
+    homepage = "https://antigravity.google";
+    license = licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with maintainers; [ ];
+    platforms = [
+      "x86_64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+    mainProgram = "antigravity";
+  };
+}


### PR DESCRIPTION

## Summary

- Add Antigravity package for macOS (x86_64 and ARM64) and Linux (x86_64)
- Supports binary distribution via DMG (macOS) and tar.gz (Linux)
- Includes autoPatchelfHook for Linux binary patching

## Test plan

- [x] Build tested on Linux x86_64
- [ ] macOS build requires hash verification


💘 Generated with Crush