### PR TITLE
gemini-cli: add xsel runtime dependency on Linux

### DIFF
--- a/packages/gemini-cli/package.nix
+++ b/packages/gemini-cli/package.nix
@@ -35,7 +35,6 @@ buildNpmPackage (finalAttrs: {
   ];
 
   buildInputs = [
-    ripgrep
     libsecret
   ];
 
@@ -64,7 +63,12 @@ buildNpmPackage (finalAttrs: {
 
     ${lib.optionalString stdenv.hostPlatform.isLinux ''
       wrapProgram $out/bin/gemini \
-        --prefix PATH : ${lib.makeBinPath [ xsel ]}
+        --prefix PATH : ${
+          lib.makeBinPath [
+            xsel
+            ripgrep
+          ]
+        }
     ''}
 
     runHook postInstall


### PR DESCRIPTION
This fixes the clipboard functionality issue where /copy command fails due to missing xsel binary.

Fixes #1128
