### PR TITLE
fix(claudebox): handle repo folders with dots in them

### DIFF
--- a/packages/claudebox/claudebox.sh
+++ b/packages/claudebox/claudebox.sh
@@ -83,7 +83,9 @@ project_dir="$(pwd)"
 # Try to find git repo root, fallback to current directory
 repo_root="$(git rev-parse --show-toplevel 2>/dev/null || echo "$project_dir")"
 
-session_prefix="$(basename "$repo_root")"
+# Sanitize session prefix: tmux treats '.' and ':' as special characters
+# in session names (used as separators in target syntax like session.window:pane)
+session_prefix="$(basename "$repo_root" | tr './:' '_')"
 session_id="$(printf '%04x%04x' $RANDOM $RANDOM)"
 session_name="${session_prefix}-${session_id}"
 


### PR DESCRIPTION
Like llm-agents.nix. Tmux would not handle the name well.