### PR TITLE
claude-code-native: init at 2.0.65

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>claude-code-native</strong> - Agentic coding tool that lives in your terminal, understands your codebase, and helps you code faster (native binary)</summary>
+
+- **Source**: binary
+- **License**: unfree
+- **Homepage**: https://github.com/anthropics/claude-code
+- **Usage**: `nix run github:numtide/llm-agents.nix#claude-code-native -- --help`
+- **Nix**: [packages/claude-code-native/package.nix](packages/claude-code-native/package.nix)
+
+</details>
+<details>
 <summary><strong>claude-code-router</strong> - Use Claude Code without an Anthropics account and route it to another LLM provider</summary>
 
 - **Source**: bytecode

--- a/packages/claude-code-native/default.nix
+++ b/packages/claude-code-native/default.nix
@@ -1,0 +1,5 @@
+{
+  pkgs,
+  ...
+}:
+pkgs.callPackage ./package.nix { }

--- a/packages/claude-code-native/hashes.json
+++ b/packages/claude-code-native/hashes.json
@@ -1,0 +1,9 @@
+{
+  "version": "2.0.65",
+  "hashes": {
+    "x86_64-darwin": "sha256-4QQN6QvUhG6jaZLJsMyVB0EMD8Clo8KpBqk4uNYfcxU=",
+    "aarch64-darwin": "sha256-RQyUxMDWVsTTMhRkEVQ96XbGtEAWN4B+ZhPzUPuMuOM=",
+    "aarch64-linux": "sha256-4zalVCvi6kToquWo+SRVNRm4wyR/PF2CIGpyWvvASMc=",
+    "x86_64-linux": "sha256-z6w9b+mTYitq/O4CYx4k5vmQySRzPmO+m3SCpWYnqco="
+  }
+}

--- a/packages/claude-code-native/package.nix
+++ b/packages/claude-code-native/package.nix
@@ -1,0 +1,79 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  makeWrapper,
+  autoPatchelfHook,
+  gcc-unwrapped,
+}:
+
+let
+  versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
+  inherit (versionData) version hashes;
+
+  bucket = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases";
+
+  platformMap = {
+    x86_64-linux = "linux-x64";
+    aarch64-linux = "linux-arm64";
+    x86_64-darwin = "darwin-x64";
+    aarch64-darwin = "darwin-arm64";
+  };
+
+  platform = stdenv.hostPlatform.system;
+  platformPath = platformMap.${platform} or (throw "Unsupported system: ${platform}");
+in
+stdenv.mkDerivation {
+  pname = "claude-code-native";
+  inherit version;
+
+  src = fetchurl {
+    url = "${bucket}/${version}/${platformPath}/claude";
+    hash = hashes.${platform};
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    autoPatchelfHook
+  ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    gcc-unwrapped.lib
+  ];
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 $src $out/bin/claude
+
+    # Disable auto-updates and telemetry by wrapping the binary
+    wrapProgram $out/bin/claude \
+      --set DISABLE_AUTOUPDATER 1 \
+      --set CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC 1 \
+      --set DISABLE_NON_ESSENTIAL_MODEL_CALLS 1 \
+      --set DISABLE_TELEMETRY 1 \
+      --unset DEV
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Agentic coding tool that lives in your terminal, understands your codebase, and helps you code faster (native binary)";
+    homepage = "https://github.com/anthropics/claude-code";
+    changelog = "https://github.com/anthropics/claude-code/releases";
+    license = licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with maintainers; [ ];
+    mainProgram = "claude";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+  };
+}

--- a/packages/claude-code-native/update.py
+++ b/packages/claude-code-native/update.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env nix
+#! nix shell --inputs-from .# nixpkgs#python3 --command python3
+
+"""Update script for claude-native package."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+
+from updater import (
+    calculate_platform_hashes,
+    fetch_text,
+    load_hashes,
+    save_hashes,
+    should_update,
+)
+
+HASHES_FILE = Path(__file__).parent / "hashes.json"
+INSTALL_SCRIPT_URL = "https://claude.ai/install.sh"
+
+PLATFORMS = {
+    "x86_64-linux": "linux-x64",
+    "aarch64-linux": "linux-arm64",
+    "x86_64-darwin": "darwin-x64",
+    "aarch64-darwin": "darwin-arm64",
+}
+
+
+def get_bucket_url() -> str:
+    """Discover bucket URL from the official install script."""
+    script = fetch_text(INSTALL_SCRIPT_URL)
+    for line in script.splitlines():
+        if line.startswith("GCS_BUCKET="):
+            return line.split("=", 1)[1].strip('"')
+    msg = "Could not find GCS_BUCKET in install script"
+    raise ValueError(msg)
+
+
+def main() -> None:
+    """Update the claude-code-native package."""
+    bucket = get_bucket_url()
+    data = load_hashes(HASHES_FILE)
+    current = data["version"]
+    latest = fetch_text(f"{bucket}/stable").strip()
+
+    print(f"Current: {current}, Latest: {latest}")
+
+    if not should_update(current, latest):
+        print("Already up to date")
+        return
+
+    url_template = f"{bucket}/{latest}/{{platform}}/claude"
+    hashes = calculate_platform_hashes(url_template, PLATFORMS)
+
+    save_hashes(HASHES_FILE, {"version": latest, "hashes": hashes})
+    print(f"Updated to {latest}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds `claude-code-native` package that installs Claude Code from the official native binary distribution rather than npm.

### Why native?

The [official documentation](https://code.claude.com/docs/en/setup#native-install-recommended) now recommends native installation over npm. [Some upcoming features will be native-only](https://x.com/dmwlff/status/2001030789065240601).

Note: The native release channel seems to trail the npm version slightly (currently 2.0.65 vs 2.0.71).

### Tested

- Built and ran on aarch64-darwin
- Built and ran on x86_64-linux
- Verified `update.py` fetches latest version and updates hashes correctly

---

### Questions

- Should this eventually replace `claude-code` entirely, given that native is now the recommended installation method?
- Not sure how you'll feel about the update script, I've fetched the install script each time and resolved the bucket URLs, just in case the bucket URLs end up changing - it feels a bit flakey, do you have better ideas for this?