### PR TITLE
forge,catnip,droid,cursor-agent: migrate to wrapBuddy

### DIFF
--- a/packages/catnip/default.nix
+++ b/packages/catnip/default.nix
@@ -1,1 +1,8 @@
-{ pkgs }: pkgs.callPackage ./package.nix { }
+{
+  pkgs,
+  perSystem,
+  ...
+}:
+pkgs.callPackage ./package.nix {
+  inherit (perSystem.self) wrapBuddy;
+}

--- a/packages/catnip/package.nix
+++ b/packages/catnip/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchurl,
-  autoPatchelfHook,
+  wrapBuddy,
   gcc-unwrapped,
 }:
 
@@ -29,7 +29,7 @@ stdenv.mkDerivation {
     hash = hashes.${platform};
   };
 
-  nativeBuildInputs = lib.optionals stdenv.isLinux [ autoPatchelfHook ];
+  nativeBuildInputs = lib.optionals stdenv.isLinux [ wrapBuddy ];
 
   buildInputs = lib.optionals stdenv.isLinux [
     gcc-unwrapped.lib

--- a/packages/cursor-agent/default.nix
+++ b/packages/cursor-agent/default.nix
@@ -1,1 +1,8 @@
-{ pkgs }: pkgs.callPackage ./package.nix { }
+{
+  pkgs,
+  perSystem,
+  ...
+}:
+pkgs.callPackage ./package.nix {
+  inherit (perSystem.self) wrapBuddy;
+}

--- a/packages/cursor-agent/package.nix
+++ b/packages/cursor-agent/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchurl,
   makeWrapper,
-  autoPatchelfHook,
+  wrapBuddy,
 }:
 
 let
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     makeWrapper
   ]
   ++ lib.optionals stdenv.isLinux [
-    autoPatchelfHook
+    wrapBuddy
   ];
 
   buildInputs = lib.optionals stdenv.isLinux [

--- a/packages/droid/default.nix
+++ b/packages/droid/default.nix
@@ -1,1 +1,8 @@
-{ pkgs }: pkgs.callPackage ./package.nix { }
+{
+  pkgs,
+  perSystem,
+  ...
+}:
+pkgs.callPackage ./package.nix {
+  inherit (perSystem.self) wrapBuddy;
+}

--- a/packages/droid/package.nix
+++ b/packages/droid/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchurl,
   makeWrapper,
-  autoPatchelfHook,
+  wrapBuddy,
   gcc-unwrapped,
 }:
 
@@ -38,7 +38,7 @@ stdenv.mkDerivation {
     makeWrapper
   ]
   ++ lib.optionals stdenv.isLinux [
-    autoPatchelfHook
+    wrapBuddy
   ];
 
   buildInputs = lib.optionals stdenv.isLinux [

--- a/packages/forge/default.nix
+++ b/packages/forge/default.nix
@@ -1,5 +1,8 @@
 {
   pkgs,
+  perSystem,
   ...
 }:
-pkgs.callPackage ./package.nix { }
+pkgs.callPackage ./package.nix {
+  inherit (perSystem.self) wrapBuddy;
+}

--- a/packages/forge/package.nix
+++ b/packages/forge/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchurl,
   makeWrapper,
-  autoPatchelfHook,
+  wrapBuddy,
   gcc-unwrapped,
 }:
 
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     makeWrapper
   ]
   ++ lib.optionals stdenv.isLinux [
-    autoPatchelfHook
+    wrapBuddy
   ];
 
   buildInputs = lib.optionals stdenv.isLinux [


### PR DESCRIPTION
Replace autoPatchelfHook with wrapBuddy for these packages. wrapBuddy patches entry points instead of rewriting ELF headers, which is more reliable for binaries with unusual layouts.

Also document how wrapBuddy handles dependencies in README.