### PR TITLE
fix(opencode): Upgrade to v1.0.191 and add missing @ai-sdk dependencies

### DIFF
--- a/packages/opencode/add-ai-sdk-deps.patch
+++ b/packages/opencode/add-ai-sdk-deps.patch
@@ -1,0 +1,17 @@
+--- a/packages/opencode/package.json
++++ b/packages/opencode/package.json
+@@ -107,6 +107,13 @@
+     "xdg-basedir": "5.1.0",
+     "yargs": "18.0.0",
+     "zod": "catalog:",
+-    "zod-to-json-schema": "3.24.5"
++    "zod-to-json-schema": "3.24.5",
++    "@ai-sdk/cerebras": "1.0.33",
++    "@ai-sdk/cohere": "2.0.21",
++    "@ai-sdk/deepinfra": "1.0.30",
++    "@ai-sdk/gateway": "2.0.23",
++    "@ai-sdk/groq": "2.0.33",
++    "@ai-sdk/perplexity": "2.0.22",
++    "@ai-sdk/togetherai": "1.0.30"
+   }
+ }

--- a/packages/opencode/hashes.json
+++ b/packages/opencode/hashes.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.186",
-  "hash": "sha256-v1vCQmpDQVkijELREFpozqumhpq8HQ+eoKW0+OEdsrY=",
-  "outputHash": "sha256-NaLKlLke9K2/1+2NhrWIlsNRFL674PraWmBCbzkEk6c="
+  "version": "1.0.191",
+  "hash": "sha256-2cKbixi2Z4Gv+piSjtt9TlUBeW/j5FKOM/9qRDK5IJM=",
+  "outputHash": "sha256-SMXghT8NltGqiP8P/rnmEVDbEVL72SXb0aT84bKLeuc="
 }

--- a/packages/opencode/package.nix
+++ b/packages/opencode/package.nix
@@ -45,6 +45,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
     dontConfigure = true;
 
+    patches = finalAttrs.patches;
+
     buildPhase = ''
       runHook preBuild
 
@@ -98,6 +100,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   patches = [
     # NOTE: Relax Bun version check to be a warning instead of an error
     ./relax-bun-version-check.patch
+    # NOTE: Add missing @ai-sdk dependencies for 1.0.191
+    ./add-ai-sdk-deps.patch
   ];
 
   dontConfigure = true;


### PR DESCRIPTION
Adds patch to include @ai-sdk/{cerebras,cohere,deepinfra,gateway,groq,perplexity,togetherai} packages that were missing from upstream package.json.

## Testing

Attempted to remove the patch to verify necessity, but build failed with:
  error: Could not resolve: '@ai-sdk/cerebras' (packages/opencode/src/provider/provider.ts:31)
  error: Could not resolve: '@ai-sdk/cohere' (packages/opencode/src/provider/provider.ts:33)
  error: Could not resolve: '@ai-sdk/gateway' (packages/opencode/src/provider/provider.ts:34)
  error: Could not resolve: '@ai-sdk/togetherai' (packages/opencode/src/provider/provider.ts:35)
  error: Could not resolve: '@ai-sdk/perplexity' (packages/opencode/src/provider/provider.ts:36)

This confirms the dependencies are required by source code imports even though they're not in upstream package.json.

## Changes

- Added `packages/opencode/add-ai-sdk-deps.patch` with 7 missing @ai-sdk dependencies
- Updated `packages/opencode/package.nix` to apply the patch
- Updated `packages/opencode/hashes.json` with new outputHash for patched dependencies