### PR TITLE
wrapBuddy: detect page size at runtime from auxv

### DIFF
--- a/packages/wrapBuddy/types.h
+++ b/packages/wrapBuddy/types.h
@@ -13,10 +13,6 @@
 /* ssize_t is not in freestanding headers */
 typedef long ssize_t;
 
-/* Memory constants */
-#define PAGE_SIZE 4096
-#define PAGE_MASK (~((uint64_t)PAGE_SIZE - 1))
-
 /* File constants */
 #define O_RDONLY 0
 #define SEEK_SET 0
@@ -50,6 +46,7 @@ typedef long ssize_t;
 #define AT_NULL 0
 #define AT_PHDR 3
 #define AT_PHNUM 5
+#define AT_PAGESZ 6
 #define AT_BASE 7
 #define AT_ENTRY 9
 

--- a/packages/wrapBuddy/wrap-buddy.py
+++ b/packages/wrapBuddy/wrap-buddy.py
@@ -39,7 +39,6 @@ PT_INTERP = 3
 PF_X = 1
 PF_W = 2
 PF_R = 4
-PAGE_SIZE = 4096
 
 # ASCII printable range (for C string escaping)
 ASCII_PRINTABLE_MIN = 32  # space character


### PR DESCRIPTION

Systems like Asahi Linux use 16KB pages instead of the standard 4KB,
causing mprotect() to fail with EINVAL when using hardcoded 4096.

Read AT_PAGESZ from the auxiliary vector at runtime instead of
hardcoding PAGE_SIZE. This allows wrapBuddy to work on any Linux
system regardless of page size.

Fixes: #1545
