### PR TITLE
claude-code: suppress installation method warning from doctor

### DIFF
--- a/packages/claude-code/package.nix
+++ b/packages/claude-code/package.nix
@@ -45,13 +45,15 @@ stdenv.mkDerivation {
     runHook postInstall
   '';
 
-  # Disable auto-updates and telemetry by wrapping the binary
+  # Disable auto-updates, telemetry, and installation method warnings
+  # See: https://github.com/anthropics/claude-code/issues/15592
   postFixup = ''
     wrapProgram $out/bin/claude \
       --set DISABLE_AUTOUPDATER 1 \
       --set CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC 1 \
       --set DISABLE_NON_ESSENTIAL_MODEL_CALLS 1 \
-      --set DISABLE_TELEMETRY 1
+      --set DISABLE_TELEMETRY 1 \
+      --set DISABLE_INSTALLATION_CHECKS 1
   '';
 
   doInstallCheck = true;


### PR DESCRIPTION

Set DISABLE_INSTALLATION_CHECKS=1 to suppress the spurious warning
"Running native installation but config install method is 'unknown'"
when running `claude doctor`.

This is the correct fix for system package managers that don't create
the ~/.claude/.config.json file with installMethod set.

Fixes: https://github.com/numtide/llm-agents.nix/issues/1574
Upstream: https://github.com/anthropics/claude-code/issues/15592
