### PR TITLE
coding-agent-search: generate and install man page

### DIFF
--- a/packages/coding-agent-search/package.nix
+++ b/packages/coding-agent-search/package.nix
@@ -8,6 +8,7 @@
   installShellFiles,
   versionCheckHook,
   onnxruntime,
+  stdenv,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -49,11 +50,15 @@ rustPlatform.buildRustPackage rec {
   # Tests require a writable HOME directory
   doCheck = false;
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     # Generate shell completions
     $out/bin/cass completions bash > cass.bash && installShellCompletion --bash cass.bash
     $out/bin/cass completions fish > cass.fish && installShellCompletion --fish cass.fish
     $out/bin/cass completions zsh > cass.zsh && installShellCompletion --zsh cass.zsh
+
+    # Generate man page
+    $out/bin/cass man > cass.1
+    installManPage cass.1
   '';
 
   doInstallCheck = true;


### PR DESCRIPTION

The 'cass' binary includes a 'man' subcommand that generates its own
manual page.

Invoke this command during the postInstall phase to generate and install
the man page to /share/man/man1/cass.1.

Since this requires executing the compiled binary, wrap the postInstall
script in a check for stdenv.buildPlatform.canExecute stdenv.hostPlatform
to ensure cross-compilation builds do not fail.


