### PR TITLE
npm: pin to nodejs_24 and use fetchNpmDepsWithPackuments

### DIFF
--- a/lib/fetch-npm-deps.nix
+++ b/lib/fetch-npm-deps.nix
@@ -2,6 +2,9 @@
 # This builds a vendored prefetch-npm-deps with packument fetching support,
 # which is needed for npm workspace support.
 # TODO: Remove this once the upstream PR is merged into nixpkgs.
+#
+# Pin to nodejs_24 to ensure consistent npmDepsHash across nixpkgs versions.
+# See: https://github.com/numtide/llm-agents.nix/issues/1644
 {
   lib,
   stdenv,
@@ -15,12 +18,14 @@
   gzip,
   cacert,
   config,
-  nodejs,
+  nodejs_24,
   srcOnly,
   diffutils,
   jq,
 }:
 let
+  nodejs = nodejs_24;
+
   # Build prefetch-npm-deps from vendored source with packument support
   prefetch-npm-deps = rustPlatform.buildRustPackage {
     pname = "prefetch-npm-deps";

--- a/packages/amp/default.nix
+++ b/packages/amp/default.nix
@@ -3,6 +3,10 @@
   perSystem,
   ...
 }:
+let
+  npmPackumentSupport = pkgs.callPackage ../../lib/fetch-npm-deps.nix { };
+in
 pkgs.callPackage ./package.nix {
   inherit (perSystem.self) versionCheckHomeHook;
+  inherit (npmPackumentSupport) fetchNpmDepsWithPackuments npmConfigHook;
 }

--- a/packages/amp/hashes.json
+++ b/packages/amp/hashes.json
@@ -1,5 +1,5 @@
 {
   "version": "0.0.1767441688-g5b15f4",
   "sourceHash": "sha256-z213rH7YzivYT0cBInNcyfZG7LXhdkKgIt4Q+gtUDSM=",
-  "npmDepsHash": "sha256-g80fmyDxpU5TumTduNa/a4TZNvVNfryIdsUVeBqnKfU="
+  "npmDepsHash": "sha256-QaU1nBGirsvhHmVbS4ijnD29Va8h9kD/Kj4XWQWpS64="
 }

--- a/packages/amp/package.nix
+++ b/packages/amp/package.nix
@@ -2,7 +2,8 @@
   lib,
   buildNpmPackage,
   fetchurl,
-  fetchNpmDeps,
+  fetchNpmDepsWithPackuments,
+  npmConfigHook,
   ripgrep,
   runCommand,
   versionCheckHook,
@@ -25,15 +26,19 @@ let
   '';
 in
 buildNpmPackage rec {
+  inherit npmConfigHook;
   pname = "amp";
   inherit version;
 
   src = srcWithLock;
 
-  npmDeps = fetchNpmDeps {
+  npmDeps = fetchNpmDepsWithPackuments {
     inherit src;
+    name = "${pname}-${version}-npm-deps";
     hash = versionData.npmDepsHash;
+    cacheVersion = 2;
   };
+  makeCacheWritable = true;
 
   # The package from npm is already built
   dontNpmBuild = true;

--- a/packages/claude-code-acp/default.nix
+++ b/packages/claude-code-acp/default.nix
@@ -2,4 +2,9 @@
   pkgs,
   ...
 }:
-pkgs.callPackage ./package.nix { }
+let
+  npmPackumentSupport = pkgs.callPackage ../../lib/fetch-npm-deps.nix { };
+in
+pkgs.callPackage ./package.nix {
+  inherit (npmPackumentSupport) fetchNpmDepsWithPackuments npmConfigHook;
+}

--- a/packages/claude-code-acp/package.nix
+++ b/packages/claude-code-acp/package.nix
@@ -2,9 +2,12 @@
   lib,
   buildNpmPackage,
   fetchFromGitHub,
+  fetchNpmDepsWithPackuments,
+  npmConfigHook,
 }:
 
 buildNpmPackage rec {
+  inherit npmConfigHook;
   pname = "claude-code-acp";
   version = "0.12.6";
 
@@ -15,7 +18,13 @@ buildNpmPackage rec {
     hash = "sha256-RJ3nl86fGEEh4RgZoLiyz9XOC4wlP7WxuJzavZLsjMI=";
   };
 
-  npmDepsHash = "sha256-3JLqokF1nk41S198NzYDT6xH8QiRm1yPBotyBnXu3E0=";
+  npmDeps = fetchNpmDepsWithPackuments {
+    inherit src;
+    name = "${pname}-${version}-npm-deps";
+    hash = "sha256-hhPp/1bk9iYHw1EnmMkCyuOaIvina0XRG76WBafLtDw=";
+    cacheVersion = 2;
+  };
+  makeCacheWritable = true;
 
   # Disable install scripts to avoid platform-specific dependency fetching issues
   npmFlags = [ "--ignore-scripts" ];

--- a/packages/claude-code-npm/default.nix
+++ b/packages/claude-code-npm/default.nix
@@ -1,1 +1,8 @@
-{ pkgs, ... }: pkgs.callPackage ./package.nix { }
+{ pkgs, ... }:
+let
+  npmPackumentSupport = pkgs.callPackage ../../lib/fetch-npm-deps.nix { };
+in
+pkgs.callPackage ./package.nix {
+  inherit (npmPackumentSupport) fetchNpmDepsWithPackuments npmConfigHook;
+  nodejs = pkgs.nodejs_24;
+}

--- a/packages/claude-code-npm/hashes.json
+++ b/packages/claude-code-npm/hashes.json
@@ -1,5 +1,5 @@
 {
   "version": "2.0.76",
   "hash": "sha256-46IqiGJZrZM4vVcanZj/vY4uxFH3/4LxNA+Qb6iIHDk=",
-  "npmDepsHash": "sha256-mDErPWWqOe+3fKriTBLNCzXP48pmmlOMoB+kCP4FoT8="
+  "npmDepsHash": "sha256-LkE/7ttRW9Ym2nLRGjDgUgNIsb9b2EB+7tN6vZ+sbwg="
 }

--- a/packages/copilot-cli/default.nix
+++ b/packages/copilot-cli/default.nix
@@ -1,1 +1,6 @@
-{ pkgs }: pkgs.callPackage ./package.nix { }
+{
+  pkgs,
+  perSystem,
+  ...
+}:
+pkgs.callPackage ./package.nix { inherit (perSystem.self) wrapBuddy; }

--- a/packages/gemini-cli/default.nix
+++ b/packages/gemini-cli/default.nix
@@ -1,4 +1,8 @@
 { pkgs }:
+let
+  npmPackumentSupport = pkgs.callPackage ../../lib/fetch-npm-deps.nix { };
+in
 pkgs.callPackage ./package.nix {
   darwinOpenptyHook = pkgs.callPackage ../darwinOpenptyHook { };
+  inherit (npmPackumentSupport) fetchNpmDepsWithPackuments npmConfigHook;
 }

--- a/packages/gemini-cli/package.nix
+++ b/packages/gemini-cli/package.nix
@@ -11,9 +11,12 @@
   makeBinaryWrapper,
   versionCheckHook,
   xsel,
+  fetchNpmDepsWithPackuments,
+  npmConfigHook,
 }:
 
 buildNpmPackage (finalAttrs: {
+  inherit npmConfigHook;
   pname = "gemini-cli";
   version = "0.22.5";
 
@@ -24,7 +27,13 @@ buildNpmPackage (finalAttrs: {
     hash = "sha256-3d9Lq3IulIgp4QGNtSvkwz10kfygX6vsmVdlU3lE6Gw=";
   };
 
-  npmDepsHash = "sha256-6NqpkUgez7CqQAMDQW3Zdi86sF5qXseKXMw1Vw/5zWU=";
+  npmDeps = fetchNpmDepsWithPackuments {
+    inherit (finalAttrs) src;
+    name = "${finalAttrs.pname}-${finalAttrs.version}-npm-deps";
+    hash = "sha256-TFQJ0mLlYQAlDSOuabli9B1nwTyUaIY/jHxT5QFYd4w=";
+    cacheVersion = 2;
+  };
+  makeCacheWritable = true;
 
   nativeBuildInputs = [
     pkg-config

--- a/packages/kilocode-cli/default.nix
+++ b/packages/kilocode-cli/default.nix
@@ -1,1 +1,7 @@
-{ pkgs, ... }: pkgs.callPackage ./package.nix { }
+{ pkgs, ... }:
+let
+  npmPackumentSupport = pkgs.callPackage ../../lib/fetch-npm-deps.nix { };
+in
+pkgs.callPackage ./package.nix {
+  inherit (npmPackumentSupport) fetchNpmDepsWithPackuments npmConfigHook;
+}

--- a/packages/kilocode-cli/package.nix
+++ b/packages/kilocode-cli/package.nix
@@ -2,10 +2,13 @@
   buildNpmPackage,
   fetchzip,
   lib,
+  fetchNpmDepsWithPackuments,
+  npmConfigHook,
   ripgrep,
   versionCheckHook,
 }:
 buildNpmPackage (finalAttrs: {
+  inherit npmConfigHook;
   pname = "kilocode-cli";
   version = "0.18.1";
 
@@ -14,7 +17,13 @@ buildNpmPackage (finalAttrs: {
     hash = "sha256-7I+a7N2HY6ZDEdWzKoyL+VW0ffVITSn1Oa7vMCjMYSA=";
   };
 
-  npmDepsHash = "sha256-csg53Yp4EtRvAyVoFh8DAuoQ7op3EYBYkGiUxhI5Vs8=";
+  npmDeps = fetchNpmDepsWithPackuments {
+    inherit (finalAttrs) src;
+    name = "${finalAttrs.pname}-${finalAttrs.version}-npm-deps";
+    hash = "sha256-rwp00D/u/LPhHRMD+HfdO6qyJ2fNHwcUpyNIXxuTTJs=";
+    cacheVersion = 2;
+  };
+  makeCacheWritable = true;
 
   buildInputs = [
     ripgrep

--- a/packages/openskills/default.nix
+++ b/packages/openskills/default.nix
@@ -1,1 +1,8 @@
-{ pkgs, flake }: pkgs.callPackage ./package.nix { inherit flake; }
+{ pkgs, flake }:
+let
+  npmPackumentSupport = pkgs.callPackage ../../lib/fetch-npm-deps.nix { };
+in
+pkgs.callPackage ./package.nix {
+  inherit flake;
+  inherit (npmPackumentSupport) fetchNpmDepsWithPackuments npmConfigHook;
+}

--- a/packages/openskills/package.nix
+++ b/packages/openskills/package.nix
@@ -3,9 +3,12 @@
   buildNpmPackage,
   fetchFromGitHub,
   flake,
+  fetchNpmDepsWithPackuments,
+  npmConfigHook,
 }:
 
 buildNpmPackage (finalAttrs: {
+  inherit npmConfigHook;
   pname = "openskills";
   version = "1.3.0";
 
@@ -16,7 +19,13 @@ buildNpmPackage (finalAttrs: {
     hash = "sha256-JLPxG8PbCSRLm6DFxSSbE94pf+Ur1ME5uF5f1z2Jhjw=";
   };
 
-  npmDepsHash = "sha256-unmxbQHOHsKF0mGCPP1eSe2H1cm7nMsTwObkF9MN2yQ=";
+  npmDeps = fetchNpmDepsWithPackuments {
+    inherit (finalAttrs) src;
+    name = "${finalAttrs.pname}-${finalAttrs.version}-npm-deps";
+    hash = "sha256-JA9YH3Qro36ooKJz6H1N3DLQJdbmjFquY2zPKbdc2h8=";
+    cacheVersion = 2;
+  };
+  makeCacheWritable = true;
 
   meta = {
     description = "Universal skills loader for AI coding agents - install and load Anthropic SKILL.md format skills in any agent";


### PR DESCRIPTION
Pin npm packages to nodejs_24 to ensure consistent npmDepsHash across nixpkgs versions. npm 11 has stricter cache validation semantics that break builds when nixpkgs upgrades nodejs.

Use fetchNpmDepsWithPackuments with cacheVersion=2 for packages that have a package-lock.json, which provides better packument caching.

For copilot-cli, switch to stdenv.mkDerivation since all dependencies are bundled in the tarball - no npm machinery needed. Add wrapBuddy for Linux ELF binary patching.

Fixes:  #1644