### PR TITLE
pi: add makeWrapper to fix env variable in PATH

### DIFF
--- a/packages/pi/package.nix
+++ b/packages/pi/package.nix
@@ -4,6 +4,7 @@
   fetchurl,
   fetchNpmDepsWithPackuments,
   npmConfigHook,
+  makeWrapper,
   fd,
   ripgrep,
   runCommand,
@@ -40,6 +41,8 @@ buildNpmPackage {
     cacheVersion = 2;
   };
   makeCacheWritable = true;
+
+  nativeBuildInputs = [ makeWrapper ];
 
   # The package from npm is already built
   dontNpmBuild = true;


### PR DESCRIPTION
Looks like wrapProgram somehow still works to add `fd` and `ripgrep` even when `makeWrapper` is not included, but it fails to update the path. I needed to add it so that it also updates the path to add `PI_SKIP_VERSION_CHECK`