### PR TITLE
ccusage-amp, ccusage-opencode, ccusage-pi: init at 18.0.5

### DIFF
--- a/packages/ccusage-amp/default.nix
+++ b/packages/ccusage-amp/default.nix
@@ -1,0 +1,10 @@
+{
+  pkgs,
+  flake,
+  perSystem,
+  ...
+}:
+pkgs.callPackage ./package.nix {
+  inherit flake;
+  inherit (perSystem.self) versionCheckHomeHook;
+}

--- a/packages/ccusage-amp/package.nix
+++ b/packages/ccusage-amp/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  stdenv,
+  fetchzip,
+  bun,
+  flake,
+  versionCheckHook,
+  versionCheckHomeHook,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "ccusage-amp";
+  version = "18.0.5";
+
+  src = fetchzip {
+    url = "https://registry.npmjs.org/@ccusage/amp/-/amp-${version}.tgz";
+    hash = "sha256-2s7s/Y4ppDBVM0BJXc1c7yRXFACco8VYTopd2ej4898=";
+  };
+
+  nativeBuildInputs = [ bun ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+
+    cp -r dist/* $out/bin/
+
+    chmod +x $out/bin/index.js
+    mv $out/bin/index.js $out/bin/ccusage-amp
+
+    substituteInPlace $out/bin/ccusage-amp \
+      --replace-fail "#!/usr/bin/env node" "#!${bun}/bin/bun"
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    versionCheckHomeHook
+  ];
+
+  meta = with lib; {
+    description = "Usage analysis tool for Amp CLI sessions";
+    homepage = "https://github.com/ryoppippi/ccusage";
+    license = licenses.mit;
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
+    maintainers = with flake.lib.maintainers; [ ryoppippi ];
+    mainProgram = "ccusage-amp";
+    platforms = platforms.all;
+  };
+}

--- a/packages/ccusage-opencode/default.nix
+++ b/packages/ccusage-opencode/default.nix
@@ -1,0 +1,10 @@
+{
+  pkgs,
+  flake,
+  perSystem,
+  ...
+}:
+pkgs.callPackage ./package.nix {
+  inherit flake;
+  inherit (perSystem.self) versionCheckHomeHook;
+}

--- a/packages/ccusage-opencode/package.nix
+++ b/packages/ccusage-opencode/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  stdenv,
+  fetchzip,
+  bun,
+  flake,
+  versionCheckHook,
+  versionCheckHomeHook,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "ccusage-opencode";
+  version = "18.0.5";
+
+  src = fetchzip {
+    url = "https://registry.npmjs.org/@ccusage/opencode/-/opencode-${version}.tgz";
+    hash = "sha256-bHB6BHs1uTtgpt9Jww8rydBXVZK/9jrdpThI99aDC5I=";
+  };
+
+  nativeBuildInputs = [ bun ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+
+    cp -r dist/* $out/bin/
+
+    chmod +x $out/bin/index.js
+    mv $out/bin/index.js $out/bin/ccusage-opencode
+
+    substituteInPlace $out/bin/ccusage-opencode \
+      --replace-fail "#!/usr/bin/env node" "#!${bun}/bin/bun"
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    versionCheckHomeHook
+  ];
+
+  meta = with lib; {
+    description = "Usage analysis tool for OpenCode sessions";
+    homepage = "https://github.com/ryoppippi/ccusage";
+    license = licenses.mit;
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
+    maintainers = with flake.lib.maintainers; [ ryoppippi ];
+    mainProgram = "ccusage-opencode";
+    platforms = platforms.all;
+  };
+}

--- a/packages/ccusage-pi/default.nix
+++ b/packages/ccusage-pi/default.nix
@@ -1,0 +1,10 @@
+{
+  pkgs,
+  flake,
+  perSystem,
+  ...
+}:
+pkgs.callPackage ./package.nix {
+  inherit flake;
+  inherit (perSystem.self) versionCheckHomeHook;
+}

--- a/packages/ccusage-pi/package.nix
+++ b/packages/ccusage-pi/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  stdenv,
+  fetchzip,
+  bun,
+  flake,
+  versionCheckHook,
+  versionCheckHomeHook,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "ccusage-pi";
+  version = "18.0.5";
+
+  src = fetchzip {
+    url = "https://registry.npmjs.org/@ccusage/pi/-/pi-${version}.tgz";
+    hash = "sha256-8QKNXMjzi+TwlygXvL5W1H5oyk0cJXsXl5jh5j+HQ14=";
+  };
+
+  nativeBuildInputs = [ bun ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+
+    cp -r dist/* $out/bin/
+
+    chmod +x $out/bin/index.js
+    mv $out/bin/index.js $out/bin/ccusage-pi
+
+    substituteInPlace $out/bin/ccusage-pi \
+      --replace-fail "#!/usr/bin/env node" "#!${bun}/bin/bun"
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    versionCheckHomeHook
+  ];
+
+  meta = with lib; {
+    description = "Pi-agent usage tracking for Claude Max";
+    homepage = "https://github.com/ryoppippi/ccusage";
+    license = licenses.mit;
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
+    maintainers = with flake.lib.maintainers; [ ryoppippi ];
+    mainProgram = "ccusage-pi";
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
## Summary

Add ccusage variant packages for monitoring usage of different AI coding tools:

- **ccusage-amp**: Usage analysis for Amp CLI sessions
- **ccusage-opencode**: Usage analysis for OpenCode sessions
- **ccusage-pi**: Pi-agent usage tracking for Claude Max

These packages are part of the [ccusage](https://github.com/ryoppippi/ccusage) project and complement the existing `ccusage` and `ccusage-codex` packages.

## Test plan

- [x] Build `ccusage-amp` locally
- [x] Build `ccusage-opencode` locally
- [x] Build `ccusage-pi` locally
- [x] All version checks pass