### PR TITLE
cc-sdd: init at 2.0.5

### DIFF
--- a/packages/cc-sdd/default.nix
+++ b/packages/cc-sdd/default.nix
@@ -1,0 +1,10 @@
+{
+  pkgs,
+  flake,
+  perSystem,
+  ...
+}:
+pkgs.callPackage ./package.nix {
+  inherit flake;
+  inherit (perSystem.self) versionCheckHomeHook;
+}

--- a/packages/cc-sdd/package.nix
+++ b/packages/cc-sdd/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  stdenv,
+  fetchzip,
+  bun,
+  flake,
+  versionCheckHook,
+  versionCheckHomeHook,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "cc-sdd";
+  version = "2.0.5";
+
+  src = fetchzip {
+    url = "https://registry.npmjs.org/cc-sdd/-/cc-sdd-${version}.tgz";
+    hash = "sha256-4wQVFEWh7TIXnQDxd/2RFLqxRJ1QsG0n9LrUkczMy58=";
+  };
+
+  nativeBuildInputs = [ bun ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/lib/cc-sdd/dist
+
+    cp -r dist/* $out/lib/cc-sdd/dist/
+    cp -r templates $out/lib/cc-sdd/
+    cp package.json $out/lib/cc-sdd/
+
+    chmod +x $out/lib/cc-sdd/dist/cli.js
+
+    substituteInPlace $out/lib/cc-sdd/dist/cli.js \
+      --replace-fail "#!/usr/bin/env node" "#!${bun}/bin/bun"
+
+    ln -s $out/lib/cc-sdd/dist/cli.js $out/bin/cc-sdd
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    versionCheckHomeHook
+  ];
+
+  meta = with lib; {
+    description = "Spec-driven development framework for AI coding agents";
+    homepage = "https://github.com/gotalab/cc-sdd";
+    license = licenses.mit;
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
+    maintainers = with flake.lib.maintainers; [ ryoppippi ];
+    mainProgram = "cc-sdd";
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
## Summary

Add cc-sdd, a spec-driven development framework for AI coding agents.

Key features:
- Enforces "requirements → design → tasks → implementation" methodology
- Inspired by the Kiro IDE approach
- Supports 7 AI agents: Claude Code, Cursor, Codex, GitHub Copilot, Gemini CLI, Windsurf, Qwen Code
- Multi-language support (13 languages)

Homepage: https://github.com/gotalab/cc-sdd

## Test plan

- [x] Build locally
- [x] Version check passes