### PR TITLE
copilot-language-server: init at 1.408.0

### DIFF
--- a/packages/copilot-language-server/default.nix
+++ b/packages/copilot-language-server/default.nix
@@ -1,0 +1,11 @@
+{
+  pkgs,
+  ...
+}:
+let
+  npmPackumentSupport = pkgs.callPackage ../../lib/fetch-npm-deps.nix { };
+in
+pkgs.callPackage ./package.nix {
+  inherit (npmPackumentSupport) fetchNpmDepsWithPackuments npmConfigHook;
+  nodejs = pkgs.nodejs_24;
+}

--- a/packages/copilot-language-server/hashes.json
+++ b/packages/copilot-language-server/hashes.json
@@ -1,0 +1,5 @@
+{
+  "version": "1.408.0",
+  "hash": "sha256-7+A2rGqf8/TNRrDaPaHWWGayGk0O4IGlF6LoeQi1Mfg=",
+  "npmDepsHash": "sha256-nDNXMtdV2reY6ADIQgF+MQLVTUqSNC3iJcltRrb+N/8="
+}

--- a/packages/copilot-language-server/package-lock.json
+++ b/packages/copilot-language-server/package-lock.json
@@ -1,0 +1,116 @@
+{
+    "name": "@github/copilot-language-server",
+    "version": "1.408.0",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "@github/copilot-language-server",
+            "version": "1.408.0",
+            "license": "MIT",
+            "dependencies": {
+                "vscode-languageserver-protocol": "^3.17.5"
+            },
+            "bin": {
+                "copilot-language-server": "dist/language-server.js"
+            },
+            "optionalDependencies": {
+                "@github/copilot-language-server-darwin-arm64": "1.408.0",
+                "@github/copilot-language-server-darwin-x64": "1.408.0",
+                "@github/copilot-language-server-linux-arm64": "1.408.0",
+                "@github/copilot-language-server-linux-x64": "1.408.0",
+                "@github/copilot-language-server-win32-x64": "1.408.0"
+            }
+        },
+        "node_modules/@github/copilot-language-server-darwin-arm64": {
+            "version": "1.408.0",
+            "resolved": "https://registry.npmjs.org/@github/copilot-language-server-darwin-arm64/-/copilot-language-server-darwin-arm64-1.408.0.tgz",
+            "integrity": "sha512-K3tDkXsVNOdvPrWN+Q4uE2Tbje2uNHu/8Ff+i5PusDGLD5XA+TN/artkMYSdui049WQcC1P5nj5ucGmhms2HUA==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@github/copilot-language-server-darwin-x64": {
+            "version": "1.408.0",
+            "resolved": "https://registry.npmjs.org/@github/copilot-language-server-darwin-x64/-/copilot-language-server-darwin-x64-1.408.0.tgz",
+            "integrity": "sha512-a0Oc8afR5wIFXpcfem+Os1mUw7IWsOuQj6dSuv0JZ4M3+a3R23YWYWD7t8Zqm1na/tGZta2+9bHwxJcWpxpTIQ==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@github/copilot-language-server-linux-arm64": {
+            "version": "1.408.0",
+            "resolved": "https://registry.npmjs.org/@github/copilot-language-server-linux-arm64/-/copilot-language-server-linux-arm64-1.408.0.tgz",
+            "integrity": "sha512-vJeycpmXtCAP4ZFjeS5rP+9moTpMO7Q6KYRCvgdck8Nz0vCEPdB6SklIzKNpgvoCUYHn4wo+kwkDYruVhz3n8A==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@github/copilot-language-server-linux-x64": {
+            "version": "1.408.0",
+            "resolved": "https://registry.npmjs.org/@github/copilot-language-server-linux-x64/-/copilot-language-server-linux-x64-1.408.0.tgz",
+            "integrity": "sha512-Ba97obTk6z0H8gvRK6Y9ZCbO3kUIFRN5iUA7kQox3DVZ3HZ9HLfstpRgWHMZQj540pPT9LVBPrM8Yf/fNvjUIA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@github/copilot-language-server-win32-x64": {
+            "version": "1.408.0",
+            "resolved": "https://registry.npmjs.org/@github/copilot-language-server-win32-x64/-/copilot-language-server-win32-x64-1.408.0.tgz",
+            "integrity": "sha512-/WcipIXuDWgPRfdo29f/kgU/r9rtsjFdI0yHbyLf6IgR8LTrciswA9qQZdJJrXDawPtif4Muza3cuQmxo2DKcg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/vscode-jsonrpc": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+            "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/vscode-languageserver-protocol": {
+            "version": "3.17.5",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+            "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode-jsonrpc": "8.2.0",
+                "vscode-languageserver-types": "3.17.5"
+            }
+        },
+        "node_modules/vscode-languageserver-types": {
+            "version": "3.17.5",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+            "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+            "license": "MIT"
+        }
+    }
+}

--- a/packages/copilot-language-server/package.nix
+++ b/packages/copilot-language-server/package.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchzip,
+  versionCheckHook,
+  fetchNpmDepsWithPackuments,
+  npmConfigHook,
+  nodejs,
+  runCommand,
+  makeWrapper,
+}:
+
+let
+  versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
+  inherit (versionData) version hash npmDepsHash;
+
+  # Create a source with the vendored package-lock.json included
+  src = runCommand "copilot-language-server-src-with-lock" { } ''
+    mkdir -p $out
+    cp -r ${
+      fetchzip {
+        url = "https://registry.npmjs.org/@github/copilot-language-server/-/copilot-language-server-${version}.tgz";
+        inherit hash;
+      }
+    }/* $out/
+    cp ${./package-lock.json} $out/package-lock.json
+  '';
+in
+buildNpmPackage {
+  inherit npmConfigHook nodejs;
+  pname = "copilot-language-server";
+  inherit version src;
+
+  npmDeps = fetchNpmDepsWithPackuments {
+    inherit src;
+    name = "copilot-language-server-${version}-npm-deps";
+    hash = npmDepsHash;
+    fetcherVersion = 2;
+  };
+  makeCacheWritable = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  # Skip optional platform-specific dependencies (not needed with Node.js 22+)
+  npmFlags = [
+    "--ignore-scripts"
+    "--omit=optional"
+  ];
+
+  dontNpmBuild = true;
+
+  # Fix the broken bin wrapper path created by npm for scoped packages
+  postInstall = ''
+    rm -rf $out/bin
+    mkdir -p $out/bin
+    makeWrapper ${nodejs}/bin/node $out/bin/copilot-language-server \
+      --add-flags "$out/lib/node_modules/@github/copilot-language-server/dist/language-server.js"
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.category = "Utilities";
+
+  meta = with lib; {
+    description = "GitHub Copilot Language Server - AI pair programmer LSP";
+    homepage = "https://github.com/github/copilot-language-server-release";
+    downloadPage = "https://www.npmjs.com/package/@github/copilot-language-server";
+    license = licenses.mit;
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
+    mainProgram = "copilot-language-server";
+    platforms = platforms.all;
+  };
+}

--- a/packages/copilot-language-server/update.py
+++ b/packages/copilot-language-server/update.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env nix
+#! nix shell --inputs-from .# nixpkgs#python3 nixpkgs#nodejs --command python3
+
+"""Update script for copilot-language-server package."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+
+from updater import (
+    calculate_dependency_hash,
+    calculate_url_hash,
+    extract_or_generate_lockfile,
+    fetch_npm_version,
+    load_hashes,
+    save_hashes,
+    should_update,
+)
+from updater.hash import DUMMY_SHA256_HASH
+from updater.nix import NixCommandError
+
+SCRIPT_DIR = Path(__file__).parent
+HASHES_FILE = SCRIPT_DIR / "hashes.json"
+NPM_PACKAGE = "@github/copilot-language-server"
+
+
+def main() -> None:
+    """Update the copilot-language-server package."""
+    data = load_hashes(HASHES_FILE)
+    current = data["version"]
+    latest = fetch_npm_version(NPM_PACKAGE)
+
+    print(f"Current: {current}, Latest: {latest}")
+
+    if not should_update(current, latest):
+        print("Already up to date")
+        return
+
+    tarball_url = f"https://registry.npmjs.org/{NPM_PACKAGE}/-/copilot-language-server-{latest}.tgz"
+
+    print("Calculating source hash...")
+    source_hash = calculate_url_hash(tarball_url, unpack=True)
+
+    if not extract_or_generate_lockfile(tarball_url, SCRIPT_DIR / "package-lock.json"):
+        return
+
+    # Prepare new data with dummy hash for dependency calculation
+    new_data = {
+        "version": latest,
+        "hash": source_hash,
+        "npmDepsHash": DUMMY_SHA256_HASH,
+    }
+
+    # Calculate npmDepsHash - only save if successful
+    try:
+        npm_deps_hash = calculate_dependency_hash(
+            ".#copilot-language-server", "npmDepsHash", HASHES_FILE, new_data
+        )
+        new_data["npmDepsHash"] = npm_deps_hash
+        save_hashes(HASHES_FILE, new_data)
+    except (ValueError, NixCommandError) as e:
+        print(f"Error: {e}")
+        return
+
+    print(f"Updated to {latest}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Add GitHub Copilot Language Server package (`@github/copilot-language-server`).

## What Changed

- New package `copilot-language-server` at version 1.408.0
- Uses `buildNpmPackage` with `fetchNpmDepsWithPackuments` to handle npm dependencies (`vscode-languageserver-protocol`)
- Node.js 24 allows running `main.js` directly, so platform-specific optional dependencies are skipped with `--omit=optional`
- Fixes scoped package (`@github/`) bin path issue via custom `postInstall` wrapper
- Includes `update.py` script for automated updates

## Why

The Copilot Language Server provides the LSP interface for GitHub Copilot, enabling AI-powered code suggestions in editors. This package makes it available through Nix.

## Testing

- Successfully built with `nix build .#copilot-language-server`
- Verified `--version` returns `1.408.0`
- Verified `--help` shows available options
- `update.py` script tested and working