### PR TITLE
docs: replace deprecated pkgs.system with pkgs.stdenv.hostPlatform.system

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,7 +452,7 @@ Add to your system configuration:
   };
 
   # In your system packages:
-  environment.systemPackages = with inputs.llm-agents.packages.${pkgs.system}; [
+  environment.systemPackages = with inputs.llm-agents.packages.${pkgs.stdenv.hostPlatform.system}; [
     claude-code
     opencode
     gemini-cli

--- a/packages/codex-acp/README.md
+++ b/packages/codex-acp/README.md
@@ -19,7 +19,7 @@ nix build github:numtide/llm-agents.nix#codex-acp
   inputs.llm-agents.url = "github:numtide/llm-agents.nix";
   
   environment.systemPackages = [
-    inputs.llm-agents.packages.${pkgs.system}.codex-acp
+    inputs.llm-agents.packages.${pkgs.stdenv.hostPlatform.system}.codex-acp
   ];
 }
 ```


### PR DESCRIPTION
Replaces the deprecated `pkgs.system` alias with `pkgs.stdenv.hostPlatform.system` in documentation examples. This alias is deprecated and will become a throw in future Nix versions.

Related: https://github.com/NixOS/nixpkgs/commit/90cb7876446bf1684ffe40ab7832de0ec1b92991