### PR TITLE
refactor(cc-sdd): switch from npm registry to GitHub source

### DIFF
--- a/packages/cc-sdd/hashes.json
+++ b/packages/cc-sdd/hashes.json
@@ -1,0 +1,5 @@
+{
+  "version": "2.0.5",
+  "hash": "sha256-w5G2DcJY12sEupcEePZzwgcR+0DVNvUnB4po5CJQtHk=",
+  "npmDepsHash": "sha256-GJJmgh/SvPwJ0wFe8pU2OcFDdQv6O5d6ZySJlN7iJw8="
+}

--- a/packages/cc-sdd/update.py
+++ b/packages/cc-sdd/update.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env nix
+#! nix shell --inputs-from .# nixpkgs#python3 nixpkgs#nodejs --command python3
+
+"""Update script for cc-sdd package."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+
+from updater import (
+    calculate_dependency_hash,
+    fetch_github_latest_release,
+    load_hashes,
+    save_hashes,
+    should_update,
+)
+from updater.hash import DUMMY_SHA256_HASH
+from updater.nix import NixCommandError, nix_prefetch_url
+
+SCRIPT_DIR = Path(__file__).parent
+HASHES_FILE = SCRIPT_DIR / "hashes.json"
+
+
+def main() -> None:
+    """Update the cc-sdd package."""
+    data = load_hashes(HASHES_FILE)
+    current = data["version"]
+    latest = fetch_github_latest_release("gotalab", "cc-sdd")
+
+    print(f"Current: {current}, Latest: {latest}")
+
+    if not should_update(current, latest):
+        print("Already up to date")
+        return
+
+    print(f"Updating cc-sdd from {current} to {latest}")
+
+    # Calculate source hash from GitHub tarball
+    tarball_url = (
+        f"https://github.com/gotalab/cc-sdd/archive/refs/tags/v{latest}.tar.gz"
+    )
+    print("Calculating source hash...")
+    source_hash = nix_prefetch_url(tarball_url, unpack=True)
+
+    # Prepare new data with dummy hash for dependency calculation
+    new_data = {
+        "version": latest,
+        "hash": source_hash,
+        "npmDepsHash": DUMMY_SHA256_HASH,
+    }
+
+    # Calculate npmDepsHash
+    try:
+        npm_deps_hash = calculate_dependency_hash(
+            ".#cc-sdd", "npmDepsHash", HASHES_FILE, new_data
+        )
+        new_data["npmDepsHash"] = npm_deps_hash
+        save_hashes(HASHES_FILE, new_data)
+    except (ValueError, NixCommandError) as e:
+        print(f"Error: {e}")
+        return
+
+    print(f"Updated to {latest}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Refactors cc-sdd package to build from GitHub source instead of fetching pre-built tarball from npm registry.

## What Changed

- Switch from `fetchzip` (npm) to `fetchFromGitHub` with `buildNpmPackage`
- Add `sourceRoot` for monorepo structure (`tools/cc-sdd`)
- Add `hashes.json` for version and hash management
- Add `update.py` script for automated version updates
- Update `sourceProvenance` from `binaryBytecode` to `fromSource`

## Why

Building from source provides better transparency and allows the package to be properly classified as `fromSource` rather than `binaryBytecode`.