### PR TITLE
vibe-kanban: add ryoppippi as maintainer

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -12,6 +12,11 @@ inputs.nixpkgs.lib.extend (
         githubId = 22575913;
         name = "Anish Lakhwara";
       };
+      ryoppippi = {
+        github = "ryoppippi";
+        githubId = 1560508;
+        name = "ryoppippi";
+      };
     };
   }
 )

--- a/packages/vibe-kanban/default.nix
+++ b/packages/vibe-kanban/default.nix
@@ -1,5 +1,6 @@
 {
   pkgs,
+  flake,
   ...
 }:
-pkgs.callPackage ./package.nix { }
+pkgs.callPackage ./package.nix { inherit flake; }

--- a/packages/vibe-kanban/package.nix
+++ b/packages/vibe-kanban/package.nix
@@ -12,6 +12,7 @@
   libgit2,
   sqlite,
   llvmPackages,
+  flake,
 }:
 
 let
@@ -116,6 +117,7 @@ rustPlatform.buildRustPackage {
     homepage = "https://github.com/BloopAI/vibe-kanban";
     license = lib.licenses.asl20;
     sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    maintainers = with flake.lib.maintainers; [ ryoppippi ];
     mainProgram = "vibe-kanban";
     platforms = lib.platforms.unix;
   };


### PR DESCRIPTION
Add ryoppippi to custom maintainers in lib/default.nix and set as maintainer for the vibe-kanban package, following the package metadata requirements.