### PR TITLE
github: redirect MCP server contributions to mcp-servers-nix

### DIFF
--- a/.github/ISSUE_TEMPLATE/package-request.yml
+++ b/.github/ISSUE_TEMPLATE/package-request.yml
@@ -9,6 +9,10 @@ body:
         **We only add packages that we personally use.** For other tools, we welcome contributions
         where you package and maintain it yourself.
 
+        **🔌 MCP Servers:** Please submit MCP server packages to
+        [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
+        That project has the infrastructure to integrate MCP servers into various agents.
+
         See existing packages in `packages/` for examples, and `AGENTS.md` for guidelines.
         Add yourself to `lib/default.nix` if you're not in nixpkgs maintainers.
   - type: input

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## Summary
+
+<!-- Briefly describe what this PR does -->
+
+## Test plan
+
+<!-- How did you test this change? -->
+
+- [ ] `nix build .#<package>` succeeds
+- [ ] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work
+
+______________________________________________________________________
+
+> [!NOTE]
+> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
+> That project has the infrastructure to integrate MCP servers into various agents.

--- a/README.md
+++ b/README.md
@@ -697,7 +697,8 @@ Contributions are welcome! Please:
 
 ## See also
 
-- https://github.com/k3d3/claude-desktop-linux-flake
+- [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) - Nix packages for MCP (Model Context Protocol) servers
+- [k3d3/claude-desktop-linux-flake](https://github.com/k3d3/claude-desktop-linux-flake) - Claude Desktop for Linux
 
 ## License
 


### PR DESCRIPTION

natsukium/mcp-servers-nix has the infrastructure to integrate MCP
servers into various agents, making it a better fit for these packages.


