### PR TITLE
copilot-cli: 0.0.372 -> 0.0.392

### DIFF
--- a/packages/copilot-cli/package.nix
+++ b/packages/copilot-cli/package.nix
@@ -10,11 +10,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "copilot-cli";
-  version = "0.0.372";
+  version = "0.0.392";
 
   src = fetchurl {
     url = "https://registry.npmjs.org/@github/copilot/-/copilot-${finalAttrs.version}.tgz";
-    hash = "sha256-GDMl8+UC6sRV8H09H1jNU5YQcGjMyCCoyeVNuTUqlbo=";
+    hash = "sha256-hkoZfFRNgTgkyXJhYQFg77BGNmfOfXKCicIJ2RwfH7Y=";
   };
 
   nativeBuildInputs = [ makeWrapper ] ++ lib.optionals stdenv.hostPlatform.isLinux [ wrapBuddy ];

--- a/packages/copilot-cli/update.py
+++ b/packages/copilot-cli/update.py
@@ -1,4 +1,0 @@
-#!/usr/bin/env python3
-"""Prevent automated copilot-cli bumps while 0.0.374 suffers a connection regression."""
-
-print("Skipping copilot-cli update: pinned to 0.0.372 due to upstream regression.")


### PR DESCRIPTION
The upstream regression in 0.0.374 has been fixed in 0.0.375 [1].
Update to the latest version and remove the update guard script.

[1] https://github.com/github/copilot-cli/issues/875#issuecomment-3788723990

Closes #1708