### PR TITLE
fix: use warnOnInstantiate  for deprecation notice

### DIFF
--- a/packages/claude-code-npm/default.nix
+++ b/packages/claude-code-npm/default.nix
@@ -1,8 +1,8 @@
 { pkgs, perSystem, ... }:
-(pkgs.lib.warn "claude-code-npm is deprecated, use claude-code instead" perSystem.self.claude-code)
-.overrideAttrs
-  (old: {
+pkgs.lib.warnOnInstantiate "claude-code-npm is deprecated, use claude-code instead" (
+  perSystem.self.claude-code.overrideAttrs (old: {
     passthru = (old.passthru or { }) // {
       hideFromDocs = true;
     };
   })
+)


### PR DESCRIPTION
## Summary
- Use `lib.warnOnInstantiate` instead of `lib.warn` for the claude-code-npm deprecation notice

## Problem
`lib.warn` triggers `abort-on-warn` during attrset evaluation, breaking flake evaluation for users with strict nixConfig settings, even when they don't reference the deprecated package.

Flake-parts uses `filterAttrs` internally to build the packages output, which forces evaluation of all package attributes. Since `lib.warn` executes during evaluation, the warning fires immediately and triggers the abort.

## Solution
`lib.warnOnInstantiate` wraps the derivation so the warning only fires when the package is actually **used** (instantiated), not during attrset evaluation. This is the correct pattern for deprecation warnings on packages.

Fixes #2116

## Test plan
- [x] Verify flake evaluates with `abort-on-warn = true` when accessing other packages (no warning)
- [x] Verify warning still appears when `claude-code-npm` is actually used