### PR TITLE
ck: init at 0.7.4

### DIFF
--- a/packages/ck/default.nix
+++ b/packages/ck/default.nix
@@ -1,0 +1,5 @@
+{
+  pkgs,
+  ...
+}:
+pkgs.callPackage ./package.nix { }

--- a/packages/ck/package.nix
+++ b/packages/ck/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  openssl,
+  onnxruntime,
+  stdenv,
+  darwinMinVersionHook,
+}:
+rustPlatform.buildRustPackage {
+  pname = "ck";
+  version = "0.7.4";
+
+  src = fetchFromGitHub {
+    owner = "BeaconBay";
+    repo = "ck";
+    tag = "0.7.4";
+    hash = "sha256-fUD/YeOMy8+oM1UA4clqto0i3gSZkyRuhxBnNb0KYTI=";
+  };
+
+  cargoHash = "sha256-ULuvrXV7+RsaHouuE2MuOWvR0KERkovGY8TVBeDIkjg=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    openssl
+    onnxruntime
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    (darwinMinVersionHook "11.0")
+  ];
+
+  cargoBuildFlags = [ "--package=ck-search" ];
+
+  # Tests require onnxruntime at runtime via @rpath
+  doCheck = false;
+
+  env = {
+    # Use system onnxruntime instead of downloading binaries
+    ORT_LIB_LOCATION = "${lib.getLib onnxruntime}/lib";
+    ORT_PREFER_DYNAMIC_LINK = "1";
+  };
+
+  postFixup = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    install_name_tool -add_rpath "${lib.getLib onnxruntime}/lib" $out/bin/ck
+  '';
+
+  passthru.category = "AI Coding Agents";
+
+  meta = with lib; {
+    description = "Local first semantic and hybrid BM25 grep / search tool for use by AI and humans!";
+    homepage = "https://github.com/BeaconBay/ck";
+    license = licenses.mit;
+    sourceProvenance = with sourceTypes; [ fromSource ];
+    mainProgram = "ck";
+  };
+}


### PR DESCRIPTION
## Summary

Add `ck` - a semantic code search tool with embeddings for AI agent integration.

Features:
  - Local-first semantic and hybrid BM25 grep/search
  - Tree-sitter parsing for code analysis
  - Multiple embedding models (BGE-Small, Mixedbread, Nomic, Jina Code)
  - Drop-in replacement for grep with `--sem`, `--lex`, `--hybrid` modes
 
## Test plan

 - [x] `nix build .#ck` succeeds
  - [x] `./result/bin/ck --version` outputs `ck 0.7.4`
  - [x] `./result/bin/ck --help` works correctly
  - [x] Package updates via `nix-update` (tested downgrade to 0.7.3 and upgrade back to 0.7.4)

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
