### PR TITLE
qmd: init at 1.0.0

### DIFF
--- a/packages/qmd/default.nix
+++ b/packages/qmd/default.nix
@@ -1,0 +1,1 @@
+{ pkgs }: pkgs.callPackage ./package.nix { }

--- a/packages/qmd/hashes.json
+++ b/packages/qmd/hashes.json
@@ -1,0 +1,10 @@
+{
+  "rev": "ba7391832dd6458aa1c027ab9402533ed56b5dd5",
+  "srcHash": "sha256-YoScForDogfm3y1iDAHwv/eL3TCYpoSKQri1hY76Izw=",
+  "bunDepsHash": {
+    "x86_64-linux": "sha256-nkFzT3IH3fr5p5Q8FRPGtYzUkwxoM2rx95RT7nvuHd0=",
+    "aarch64-linux": "sha256-NekMOHckkdlcTxX4pXg2aQ+Zo3uTvBnA/RkwnjTXABg=",
+    "x86_64-darwin": "sha256-haJ5HP9p8hP9XcsyQXyngssn0K9W7MiWHn+ir8F2d6U=",
+    "aarch64-darwin": "sha256-6k2hfzTqbqqfq/9dBCb+LdP7qRRjKKyUeq43SCeQJ14="
+  }
+}

--- a/packages/qmd/package.nix
+++ b/packages/qmd/package.nix
@@ -1,0 +1,99 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  bun,
+  makeWrapper,
+  sqlite,
+}:
+let
+  versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
+  inherit (versionData) rev srcHash bunDepsHash;
+
+  version = "1.0.0-unstable";
+
+  src = fetchFromGitHub {
+    owner = "tobi";
+    repo = "qmd";
+    inherit rev;
+    hash = srcHash;
+  };
+
+  bunDeps = stdenv.mkDerivation {
+    pname = "qmd-bun-deps";
+    inherit version src;
+
+    impureEnvVars = lib.fetchers.proxyImpureEnvVars ++ [
+      "GIT_PROXY_COMMAND"
+      "SOCKS_SERVER"
+    ];
+
+    nativeBuildInputs = [ bun ];
+
+    dontConfigure = true;
+    dontFixup = true;
+
+    buildPhase = ''
+      runHook preBuild
+
+      export HOME=$(mktemp -d)
+      bun install --no-progress --frozen-lockfile
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out
+      cp -R node_modules $out/
+
+      runHook postInstall
+    '';
+
+    outputHash =
+      bunDepsHash.${stdenv.hostPlatform.system}
+        or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+  };
+in
+stdenv.mkDerivation {
+  pname = "qmd";
+  inherit version src;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildInputs = [ sqlite ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/qmd $out/bin
+
+    cp -r ${bunDeps}/node_modules $out/lib/qmd/
+    cp -r src $out/lib/qmd/
+    cp package.json $out/lib/qmd/
+
+    makeWrapper ${bun}/bin/bun $out/bin/qmd \
+      --add-flags "$out/lib/qmd/src/qmd.ts" \
+      --set DYLD_LIBRARY_PATH "${sqlite.out}/lib" \
+      --set LD_LIBRARY_PATH "${sqlite.out}/lib"
+
+    runHook postInstall
+  '';
+
+  passthru.category = "Utilities";
+
+  meta = with lib; {
+    description = "mini cli search engine for your docs, knowledge bases, meeting notes, whatever. Tracking current sota approaches while being all local";
+    homepage = "https://github.com/tobi/qmd";
+    license = licenses.mit;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    platforms = lib.platforms.unix;
+    mainProgram = "qmd";
+  };
+}

--- a/packages/qmd/update.py
+++ b/packages/qmd/update.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env nix
+#! nix shell --inputs-from .# nixpkgs#python3 --command python3
+
+"""Update script for qmd package."""
+
+import sys
+from pathlib import Path
+from typing import cast
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+
+from updater import (
+    calculate_url_hash,
+    fetch_json,
+    load_hashes,
+    save_hashes,
+)
+
+HASHES_FILE = Path(__file__).parent / "hashes.json"
+OWNER = "tobi"
+REPO = "qmd"
+
+
+def fetch_latest_commit() -> tuple[str, str]:
+    """Fetch the latest commit SHA and date from the default branch.
+
+    Returns:
+        Tuple of (commit SHA, commit date in YYYY-MM-DD format)
+
+    """
+    url = f"https://api.github.com/repos/{OWNER}/{REPO}/commits/main"
+    data = fetch_json(url)
+    if not isinstance(data, dict):
+        msg = f"Expected dict from GitHub API, got {type(data)}"
+        raise TypeError(msg)
+
+    sha = cast("str", data["sha"])
+    # commit.committer.date is in ISO 8601 format
+    commit_date = cast("str", data["commit"]["committer"]["date"])[:10]
+    return sha, commit_date
+
+
+def main() -> None:
+    """Update the qmd package."""
+    data = load_hashes(HASHES_FILE)
+    current_rev = data["rev"]
+
+    latest_rev, commit_date = fetch_latest_commit()
+    print(f"Current rev: {current_rev[:8]}")
+    print(f"Latest rev:  {latest_rev[:8]} ({commit_date})")
+
+    if current_rev == latest_rev:
+        print("Already up to date")
+        return
+
+    print(f"Updating qmd to {latest_rev[:8]}...")
+
+    # Calculate new source hash
+    tarball_url = f"https://github.com/{OWNER}/{REPO}/archive/{latest_rev}.tar.gz"
+    print(f"Calculating source hash for {tarball_url}...")
+    src_hash = calculate_url_hash(tarball_url, unpack=True)
+    print(f"  srcHash: {src_hash}")
+
+    # Update hashes.json (keep bunDepsHash unchanged)
+    new_data = {
+        "rev": latest_rev,
+        "srcHash": src_hash,
+        "bunDepsHash": data["bunDepsHash"],
+    }
+
+    save_hashes(HASHES_FILE, new_data)
+    print(f"Updated to {latest_rev[:8]} ({commit_date})")
+    print(
+        "Note: bunDepsHash unchanged. If build fails, update manually from error output."
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Add `qmd` - mini cli search engine for your docs, knowledge bases, meeting notes, whatever. Tracking current sota approaches while being all local 

## Test plan

- [ x ] `nix build .#<package>` succeeds
- [ x ] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
