### PR TITLE
workmux: init at 0.1.100

### DIFF
--- a/packages/workmux/default.nix
+++ b/packages/workmux/default.nix
@@ -1,0 +1,8 @@
+{
+  pkgs,
+  perSystem,
+  ...
+}:
+pkgs.callPackage ./package.nix {
+  inherit (perSystem.self) versionCheckHomeHook;
+}

--- a/packages/workmux/package.nix
+++ b/packages/workmux/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  versionCheckHook,
+  versionCheckHomeHook,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "workmux";
+  version = "0.1.100";
+
+  src = fetchFromGitHub {
+    owner = "raine";
+    repo = "workmux";
+    rev = "v${version}";
+    hash = "sha256-9i+pdX6dS8KSk7QrMAIlpCqqBH+YgA8CTizVQ5xpv+A=";
+  };
+
+  cargoHash = "sha256-KnDMLpq7MOPcTAM+Nb0HrGd7oPpHhbrFEXwCg7bmGDQ=";
+
+  # Some tests require filesystem access outside the sandbox
+  doCheck = false;
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    versionCheckHomeHook
+  ];
+
+  passthru.category = "Workflow & Project Management";
+
+  meta = with lib; {
+    description = "Git worktrees + tmux windows for zero-friction parallel dev";
+    homepage = "https://github.com/raine/workmux";
+    changelog = "https://github.com/raine/workmux/blob/v${version}/CHANGELOG.md";
+    license = licenses.mit;
+    sourceProvenance = with sourceTypes; [ fromSource ];
+    mainProgram = "workmux";
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION

git worktrees + tmux windows for zero-friction parallel dev

Features a TUI dashboard for monitoring active workmux agents across
all tmux sessions.

Homepage: https://github.com/raine/workmux


