### PR TITLE
qmd: fix CUDA support on NixOS

### DIFF
--- a/packages/qmd/default.nix
+++ b/packages/qmd/default.nix
@@ -1,13 +1,14 @@
 {
   pkgs,
   flake,
+  cudaSupport ? pkgs.config.cudaSupport or false,
   ...
 }:
 let
   npmPackumentSupport = pkgs.callPackage ../../lib/fetch-npm-deps.nix { };
 in
 pkgs.callPackage ./package.nix {
-  inherit flake;
+  inherit flake cudaSupport;
   inherit (npmPackumentSupport) fetchNpmDepsWithPackuments npmConfigHook;
   inherit (pkgs) vulkan-loader autoAddDriverRunpath;
   inherit (pkgs) cudaPackages;

--- a/packages/qmd/package.nix
+++ b/packages/qmd/package.nix
@@ -120,16 +120,19 @@ buildNpmPackage {
   installPhase =
     let
       # Build LD_LIBRARY_PATH with all required libraries
-      ldLibraryPath = lib.makeLibraryPath (
-        [ sqlite.out ]
-        ++ lib.optionals effectiveCudaSupport [
-          cudaPackages.cuda_cudart
-          cudaPackages.libcublas
-        ]
-        ++ lib.optionals effectiveVulkanSupport [
-          vulkan-loader
-        ]
-      );
+      ldLibraryPath =
+        lib.makeLibraryPath (
+          [ sqlite.out ]
+          ++ lib.optionals effectiveCudaSupport [
+            cudaPackages.cuda_cudart
+            cudaPackages.libcublas
+          ]
+          ++ lib.optionals effectiveVulkanSupport [
+            vulkan-loader
+          ]
+        )
+        # Add NixOS driver path for libcuda.so.1 (loaded via dlopen at runtime)
+        + lib.optionalString effectiveCudaSupport ":/run/opengl-driver/lib";
     in
     ''
       runHook preInstall


### PR DESCRIPTION
- Pass cudaSupport through default.nix so .override works
- Add /run/opengl-driver/lib to LD_LIBRARY_PATH for libcuda.so.1 (node-llama-cpp loads CUDA via dlopen at runtime)

## Summary
Fix CUDA support for qmd on NixOS when useing `.override { cudaSupport = true; }`.

- cudaSupport not propagating through override: default.nix wasn't accepting `cudaSupport` as an arg.
- missing `libcuda.so.1` in LD_LIBRARY_PATH: node-llama-cpp loads CUDA via `dlopen` at runtime, but `/run/opengl-driver/lib` wasn't included in `LD_LIBRARY_PATH`.


## Test plan

<!-- How did you test this change? -->

- [x] `nix build .#<package>` succeeds
- [] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work
- [x] in runtime, `qmd query`, `qmd vsearch` works well.
______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
