### PR TITLE
[openclaw] Include UI build in the build phase

### DIFF
--- a/packages/openclaw/package.nix
+++ b/packages/openclaw/package.nix
@@ -48,6 +48,9 @@ stdenv.mkDerivation (finalAttrs: {
 
     pnpm build
 
+    # Build the UI
+    pnpm ui:build
+
     runHook postBuild
   '';
 


### PR DESCRIPTION
Add UI build step to the build process

https://docs.openclaw.ai/web/control-ui#building-the-ui

Tested it out via this overlay:

```nix
# Override openclaw package to build UI elements
{ inputs, ... }:
{
  flake.overlays.openclaw = (
    final: prev:
    let
      # Get the base openclaw package from llm-agents
      openclaw-base = inputs.llm-agents.legacyPackages.${prev.system}.llm-agents.openclaw or prev.llm-agents.openclaw;
    in
    {
      llm-agents = prev.llm-agents // {
        openclaw = openclaw-base.overrideAttrs (old: {
          buildPhase = old.buildPhase or "" + ''
            runHook preBuild

            # Build the main package
            pnpm build

            # Build the UI
            pnpm ui:build

            runHook postBuild
          '';
        });
      };
    }
  );
}
```

## Summary

<!-- Briefly describe what this PR does -->

## Test plan

<!-- How did you test this change? -->

- [x] `nix build .#<package>` succeeds
- [ ] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
