### PR TITLE
Get maintainer from nixpkgs rather than flake lib

### DIFF
--- a/packages/cc-sdd/default.nix
+++ b/packages/cc-sdd/default.nix
@@ -1,10 +1,8 @@
 {
   pkgs,
-  flake,
   perSystem,
   ...
 }:
 pkgs.callPackage ./package.nix {
-  inherit flake;
   inherit (perSystem.self) versionCheckHomeHook;
 }

--- a/packages/cc-sdd/package.nix
+++ b/packages/cc-sdd/package.nix
@@ -3,7 +3,6 @@
   buildNpmPackage,
   fetchFromGitHub,
   bun,
-  flake,
   versionCheckHook,
   versionCheckHomeHook,
 }:
@@ -67,7 +66,7 @@ buildNpmPackage {
     homepage = "https://github.com/gotalab/cc-sdd";
     license = licenses.mit;
     sourceProvenance = with lib.sourceTypes; [ fromSource ];
-    maintainers = with flake.lib.maintainers; [ ryoppippi ];
+    maintainers = with maintainers; [ ryoppippi ];
     mainProgram = "cc-sdd";
     platforms = platforms.all;
   };

--- a/packages/ccusage-amp/default.nix
+++ b/packages/ccusage-amp/default.nix
@@ -1,10 +1,8 @@
 {
   pkgs,
-  flake,
   perSystem,
   ...
 }:
 pkgs.callPackage ./package.nix {
-  inherit flake;
   inherit (perSystem.self) versionCheckHomeHook;
 }

--- a/packages/ccusage-amp/package.nix
+++ b/packages/ccusage-amp/package.nix
@@ -3,7 +3,6 @@
   stdenv,
   fetchzip,
   bun,
-  flake,
   versionCheckHook,
   versionCheckHomeHook,
 }:
@@ -49,7 +48,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/ryoppippi/ccusage";
     license = licenses.mit;
     sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
-    maintainers = with flake.lib.maintainers; [ ryoppippi ];
+    maintainers = with maintainers; [ ryoppippi ];
     mainProgram = "ccusage-amp";
     platforms = platforms.all;
   };

--- a/packages/ccusage-codex/default.nix
+++ b/packages/ccusage-codex/default.nix
@@ -1,10 +1,8 @@
 {
   pkgs,
-  flake,
   perSystem,
   ...
 }:
 pkgs.callPackage ./package.nix {
-  inherit flake;
   inherit (perSystem.self) versionCheckHomeHook;
 }

--- a/packages/ccusage-codex/package.nix
+++ b/packages/ccusage-codex/package.nix
@@ -3,7 +3,6 @@
   stdenv,
   fetchzip,
   bun,
-  flake,
   versionCheckHook,
   versionCheckHomeHook,
 }:
@@ -49,7 +48,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/ryoppippi/ccusage";
     license = licenses.mit;
     sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
-    maintainers = with flake.lib.maintainers; [ ryoppippi ];
+    maintainers = with maintainers; [ ryoppippi ];
     mainProgram = "ccusage-codex";
     platforms = platforms.all;
   };

--- a/packages/ccusage-opencode/default.nix
+++ b/packages/ccusage-opencode/default.nix
@@ -1,10 +1,8 @@
 {
   pkgs,
-  flake,
   perSystem,
   ...
 }:
 pkgs.callPackage ./package.nix {
-  inherit flake;
   inherit (perSystem.self) versionCheckHomeHook;
 }

--- a/packages/ccusage-opencode/package.nix
+++ b/packages/ccusage-opencode/package.nix
@@ -3,7 +3,6 @@
   stdenv,
   fetchzip,
   bun,
-  flake,
   versionCheckHook,
   versionCheckHomeHook,
 }:
@@ -49,7 +48,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/ryoppippi/ccusage";
     license = licenses.mit;
     sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
-    maintainers = with flake.lib.maintainers; [ ryoppippi ];
+    maintainers = with maintainers; [ ryoppippi ];
     mainProgram = "ccusage-opencode";
     platforms = platforms.all;
   };

--- a/packages/ccusage-pi/default.nix
+++ b/packages/ccusage-pi/default.nix
@@ -1,10 +1,8 @@
 {
   pkgs,
-  flake,
   perSystem,
   ...
 }:
 pkgs.callPackage ./package.nix {
-  inherit flake;
   inherit (perSystem.self) versionCheckHomeHook;
 }

--- a/packages/ccusage-pi/package.nix
+++ b/packages/ccusage-pi/package.nix
@@ -3,7 +3,6 @@
   stdenv,
   fetchzip,
   bun,
-  flake,
   versionCheckHook,
   versionCheckHomeHook,
 }:
@@ -49,7 +48,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/ryoppippi/ccusage";
     license = licenses.mit;
     sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
-    maintainers = with flake.lib.maintainers; [ ryoppippi ];
+    maintainers = with maintainers; [ ryoppippi ];
     mainProgram = "ccusage-pi";
     platforms = platforms.all;
   };

--- a/packages/ccusage/default.nix
+++ b/packages/ccusage/default.nix
@@ -1,10 +1,8 @@
 {
   pkgs,
-  flake,
   perSystem,
   ...
 }:
 pkgs.callPackage ./package.nix {
-  inherit flake;
   inherit (perSystem.self) versionCheckHomeHook;
 }

--- a/packages/ccusage/package.nix
+++ b/packages/ccusage/package.nix
@@ -3,7 +3,6 @@
   stdenv,
   fetchzip,
   bun,
-  flake,
   versionCheckHook,
   versionCheckHomeHook,
 }:
@@ -49,7 +48,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/ryoppippi/ccusage";
     license = licenses.mit;
     sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
-    maintainers = with flake.lib.maintainers; [ ryoppippi ];
+    maintainers = with maintainers; [ ryoppippi ];
     mainProgram = "ccusage";
     platforms = platforms.all;
   };

--- a/packages/claude-code/default.nix
+++ b/packages/claude-code/default.nix
@@ -1,10 +1,8 @@
 {
   pkgs,
   perSystem,
-  flake,
   ...
 }:
 pkgs.callPackage ./package.nix {
-  inherit flake;
   inherit (perSystem.self) wrapBuddy;
 }

--- a/packages/claude-code/package.nix
+++ b/packages/claude-code/package.nix
@@ -5,7 +5,6 @@
   makeWrapper,
   wrapBuddy,
   versionCheckHook,
-  flake,
 }:
 
 let
@@ -67,12 +66,11 @@ stdenv.mkDerivation {
     changelog = "https://github.com/anthropics/claude-code/releases";
     license = licenses.unfree;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
-    maintainers =
-      (with maintainers; [
-        malo
-        omarjatoi
-      ])
-      ++ (with flake.lib.maintainers; [ ryoppippi ]);
+    maintainers = with maintainers; [
+      malo
+      omarjatoi
+      ryoppippi
+    ];
     mainProgram = "claude";
     platforms = [
       "x86_64-linux"


### PR DESCRIPTION
## Summary

In #1878 `ryoppippi` was removed from the flake maintainers as they're in nixpkgs, but the packages were still referencing them via the flake lib. Update those references.

## Test plan

<!-- How did you test this change? -->

- [x] `nix build .#<package>` succeeds
- [ ] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
