### PR TITLE
handy: change license from unfree to MIT

### DIFF
--- a/packages/handy/package.nix
+++ b/packages/handy/package.nix
@@ -155,7 +155,7 @@ stdenv.mkDerivation {
     description = "Fast and accurate local transcription app using AI models";
     homepage = "https://handy.computer/";
     changelog = "https://github.com/cjpais/Handy/releases/tag/v${version}";
-    license = licenses.unfree;
+    license = licenses.mit;
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     maintainers = with maintainers; [ ];
     platforms = [


### PR DESCRIPTION
https://github.com/cjpais/Handy/blob/main/LICENSE

## Summary

changes handy's license to mit

## Test plan

<!-- How did you test this change? -->

- [x] `nix build .#<package>` succeeds
- [ ] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
