### PR TITLE
claude-code: fix build on macOS with sandbox

### DIFF
--- a/packages/claude-code/package.nix
+++ b/packages/claude-code/package.nix
@@ -55,6 +55,12 @@ stdenv.mkDerivation {
       --set DISABLE_INSTALLATION_CHECKS 1
   '';
 
+  # Bun links against /usr/lib/libicucore.A.dylib which needs ICU data from
+  # /usr/share/icu/ at runtime for Intl.Segmenter. The Nix macOS sandbox
+  # blocks access to /usr/share/icu/, causing "failed to initialize Segmenter".
+  # Disable the sandbox for this derivation on macOS (requires sandbox=relaxed).
+  __noChroot = stdenv.hostPlatform.isDarwin;
+
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
 


### PR DESCRIPTION
## Summary

Trying to build `claude-code` on `aarch64-darwin` with `sandbox = relaxed` results in:

```
$ nix build -L github:numtide/llm-agents.nix#packages.aarch64-darwin.claude-code
claude-code> Using versionCheckHook
claude-code> Running phase: patchPhase
claude-code> Running phase: updateAutotoolsGnuConfigScriptsPhase
claude-code> Running phase: configurePhase
claude-code> no configure script, doing nothing
claude-code> Running phase: buildPhase
claude-code> no Makefile or custom buildPhase, doing nothing
claude-code> Running phase: installPhase
claude-code> Running phase: fixupPhase
claude-code> checking for references to /nix/var/nix/builds/nix-80752-413396973/ in /nix/store/7iqiglqg566afnk5g1wkkgm3lnhlirs5-claude-code-2.1.29...
claude-code> patching script interpreter paths in /nix/store/7iqiglqg566afnk5g1wkkgm3lnhlirs5-claude-code-2.1.29
claude-code> Running phase: installCheckPhase
claude-code> Executing versionCheckPhase
claude-code> Did not find version 2.1.29 in the output of the command /nix/store/7iqiglqg566afnk5g1wkkgm3lnhlirs5-claude-code-2.1.29/bin/claude --version
claude-code> 671 | `+bA[c].replace(" at new "," at ");return N.displayName&&Y_.includes("<anonymous>")&&(Y_=Y_.replace("<anonymous>",N.displayName)),Y_}while(1<=c&&0<=a);break}}}finally{L$T=!1,Error.prepareStackTrace=M}return(M=N?N.displayName||N.name:"")?x(M):""}function BT(N,Z){switch(N.tag){case 26:case 27:case 5:return x(N.type);case 16:return x("Lazy");case 13:return N.child!==Z&&Z!==null?x("Suspense Fallback"):x("Suspense");case 19:return x("SuspenseList");case 0:case 15:return s(N.type,!1);case 11:return s(N.type.render,!1);case 1:return s(N.type,!0);case 31:return x("Activity");default:return""}}function AT(N){try{var Z="",M=null;do Z+=BT(N,M),M=N,N=N.return;while(N);return Z}catch(c){return`
claude-code> 672 | Error generating stack: `+c.message+`
claude-code> 673 | `+c.stack}}function KT(N,Z){if(typeof N==="object"&&N!==null){var M=gLT.get(N);if(M!==void 0)return M;return Z={value:N,source:Z,stack:AT(Z)},gLT.set(N,Z),Z}return{value:N,source:Z,stack:AT(Z)}}function qT(N,Z){em[yy++]=Lf,em[yy++]=De,De=N,Lf=Z}function HT(N,Z,M){gQ[Vh++]=wh,gQ[Vh++]=II,gQ[Vh++]=Kf,Kf=N;var c=wh;N=II;var a=32-xQ(c)-1;c&=~(1<<a),M+=1;var e=32-xQ(Z)+a;if(30<e){var gT=a-a%5;e=(c&(1<<gT)-1).toString(32),c>>=gT,a-=gT,wh=1<<32-xQ(Z)+a|M<<a|c,II=e+N}else wh=1<<e|M<<a|c,II=N}function XT(N){N.return!==null&&(qT(N,1),HT(N,1,0))}function UT(N){for(;N===De;)De=em[--yy],em[yy]=null,Lf=em[--yy],em[yy]=null;for(;N===Kf;)Kf=gQ[--Vh],gQ[Vh]=null,II=gQ[--Vh],gQ[Vh]=null,wh=gQ[--Vh],gQ[Vh]=null}function t(N,Z){gQ[Vh++]=wh,gQ[Vh++]=II,gQ[Vh++]=Kf,wh=Z.id,II=Z.overflow,Kf=N}function WT(N,Z){W(by,Z),W(ZI,N),W(W4,null),N=T$T(Z),J(W4),W(W4,N)}function ZT(){J(W4),J(ZI),J(by)}function IT(N){N.memoizedState!==null&&W($e,N);var Z=W4.current,M=ij(Z,N.type);Z!==M&&(W(ZI,N),W(W4,M))}function pT(N){ZI.current===N&&(J(W4),J(
claude-code> 674 |   `+(c.join(" > ")+`
claude-code> 675 |
claude-code> 676 |   `)+N.join(" > ")}return null},j8.getPublicRootInstance=function(N){if(N=N.current,!N.child)return null;switch(N.child.tag){case 27:case 5:return lj(N.child.stateNode);default:return N.child.stateNode}},j8.injectIntoDevTools=function(){var N={bundleType:0,version:WLT,rendererPackageName:hmT,currentDispatcherRef:EB,reconcilerVersion:"19.2.0"};if(NI!==null&&(N.rendererConfig=NI),typeof __REACT_DEVTOOLS_GLOBAL_HOOK__>"u")N=!1;else{var Z=__REACT_DEVTOOLS_GLOBAL_HOOK__;if(Z.isDisabled||!Z.supportsFiber)N=!0;else{try{Ef=Z.inject(N),vQ=Z}catch(M){}N=Z.checkDCE?!0:!1}}return N},j8.isAlreadyRendering=function(){return(x8&6)!==0},j8.observeVisibleRects=function(N,Z,M,c){if(!st)throw Error(_(363));N=HLT(N,Z);var a=nfR(N,M,c).disconnect;return{disconnect:function(){a()}}},j8.shouldError=function(){return null},j8.shouldSuspend=function(){return!1},j8.startHostTransition=function(N,Z,M,c){if(N.tag!==5)throw Error(_(476));var a=wQ(N).queue;I2(N,a,Z,am,M===null?A:function(){var e=wQ(N);return e.next===null&&(e=N.alternate.
claude-code>
claude-code> TypeError: failed to initialize Segmenter
claude-code>       at <anonymous> (/$bunfs/root/claude:676:20327)
claude-code>       at <anonymous> (/$bunfs/root/claude:11:1003)
claude-code>       at <anonymous> (/$bunfs/root/claude:677:50)
claude-code>       at <anonymous> (/$bunfs/root/claude:11:1003)
claude-code>       at <anonymous> (/$bunfs/root/claude:679:263)
claude-code>       at <anonymous> (/$bunfs/root/claude:11:1003)
claude-code>       at <anonymous> (/$bunfs/root/claude:689:393)
claude-code>       at <anonymous> (/$bunfs/root/claude:11:1003)
claude-code>       at <anonymous> (/$bunfs/root/claude:689:5460)
claude-code>
claude-code> Bun v1.3.5 (macOS arm64)
claude-code> Did not find version 2.1.29 in the output of the command /nix/store/7iqiglqg566afnk5g1wkkgm3lnhlirs5-claude-code-2.1.29/bin/claude --help
claude-code> 671 | `+bA[c].replace(" at new "," at ");return N.displayName&&Y_.includes("<anonymous>")&&(Y_=Y_.replace("<anonymous>",N.displayName)),Y_}while(1<=c&&0<=a);break}}}finally{L$T=!1,Error.prepareStackTrace=M}return(M=N?N.displayName||N.name:"")?x(M):""}function BT(N,Z){switch(N.tag){case 26:case 27:case 5:return x(N.type);case 16:return x("Lazy");case 13:return N.child!==Z&&Z!==null?x("Suspense Fallback"):x("Suspense");case 19:return x("SuspenseList");case 0:case 15:return s(N.type,!1);case 11:return s(N.type.render,!1);case 1:return s(N.type,!0);case 31:return x("Activity");default:return""}}function AT(N){try{var Z="",M=null;do Z+=BT(N,M),M=N,N=N.return;while(N);return Z}catch(c){return`
claude-code> 672 | Error generating stack: `+c.message+`
claude-code> 673 | `+c.stack}}function KT(N,Z){if(typeof N==="object"&&N!==null){var M=gLT.get(N);if(M!==void 0)return M;return Z={value:N,source:Z,stack:AT(Z)},gLT.set(N,Z),Z}return{value:N,source:Z,stack:AT(Z)}}function qT(N,Z){em[yy++]=Lf,em[yy++]=De,De=N,Lf=Z}function HT(N,Z,M){gQ[Vh++]=wh,gQ[Vh++]=II,gQ[Vh++]=Kf,Kf=N;var c=wh;N=II;var a=32-xQ(c)-1;c&=~(1<<a),M+=1;var e=32-xQ(Z)+a;if(30<e){var gT=a-a%5;e=(c&(1<<gT)-1).toString(32),c>>=gT,a-=gT,wh=1<<32-xQ(Z)+a|M<<a|c,II=e+N}else wh=1<<e|M<<a|c,II=N}function XT(N){N.return!==null&&(qT(N,1),HT(N,1,0))}function UT(N){for(;N===De;)De=em[--yy],em[yy]=null,Lf=em[--yy],em[yy]=null;for(;N===Kf;)Kf=gQ[--Vh],gQ[Vh]=null,II=gQ[--Vh],gQ[Vh]=null,wh=gQ[--Vh],gQ[Vh]=null}function t(N,Z){gQ[Vh++]=wh,gQ[Vh++]=II,gQ[Vh++]=Kf,wh=Z.id,II=Z.overflow,Kf=N}function WT(N,Z){W(by,Z),W(ZI,N),W(W4,null),N=T$T(Z),J(W4),W(W4,N)}function ZT(){J(W4),J(ZI),J(by)}function IT(N){N.memoizedState!==null&&W($e,N);var Z=W4.current,M=ij(Z,N.type);Z!==M&&(W(ZI,N),W(W4,M))}function pT(N){ZI.current===N&&(J(W4),J(
claude-code> 674 |   `+(c.join(" > ")+`
claude-code> 675 |
claude-code> 676 |   `)+N.join(" > ")}return null},j8.getPublicRootInstance=function(N){if(N=N.current,!N.child)return null;switch(N.child.tag){case 27:case 5:return lj(N.child.stateNode);default:return N.child.stateNode}},j8.injectIntoDevTools=function(){var N={bundleType:0,version:WLT,rendererPackageName:hmT,currentDispatcherRef:EB,reconcilerVersion:"19.2.0"};if(NI!==null&&(N.rendererConfig=NI),typeof __REACT_DEVTOOLS_GLOBAL_HOOK__>"u")N=!1;else{var Z=__REACT_DEVTOOLS_GLOBAL_HOOK__;if(Z.isDisabled||!Z.supportsFiber)N=!0;else{try{Ef=Z.inject(N),vQ=Z}catch(M){}N=Z.checkDCE?!0:!1}}return N},j8.isAlreadyRendering=function(){return(x8&6)!==0},j8.observeVisibleRects=function(N,Z,M,c){if(!st)throw Error(_(363));N=HLT(N,Z);var a=nfR(N,M,c).disconnect;return{disconnect:function(){a()}}},j8.shouldError=function(){return null},j8.shouldSuspend=function(){return!1},j8.startHostTransition=function(N,Z,M,c){if(N.tag!==5)throw Error(_(476));var a=wQ(N).queue;I2(N,a,Z,am,M===null?A:function(){var e=wQ(N);return e.next===null&&(e=N.alternate.
claude-code>
claude-code> TypeError: failed to initialize Segmenter
claude-code>       at <anonymous> (/$bunfs/root/claude:676:20327)
claude-code>       at <anonymous> (/$bunfs/root/claude:11:1003)
claude-code>       at <anonymous> (/$bunfs/root/claude:677:50)
claude-code>       at <anonymous> (/$bunfs/root/claude:11:1003)
claude-code>       at <anonymous> (/$bunfs/root/claude:679:263)
claude-code>       at <anonymous> (/$bunfs/root/claude:11:1003)
claude-code>       at <anonymous> (/$bunfs/root/claude:689:393)
claude-code>       at <anonymous> (/$bunfs/root/claude:11:1003)
claude-code>       at <anonymous> (/$bunfs/root/claude:689:5460)
claude-code>
claude-code> Bun v1.3.5 (macOS arm64)
error: path '/nix/store/7iqiglqg566afnk5g1wkkgm3lnhlirs5-claude-code-2.1.29' is not valid
error: Cannot build '/nix/store/byk8r53b2zjqrzqgskh0h9kyh7v2cm2q-claude-code-2.1.29.drv'.
       Reason: builder failed with exit code 1.
       Output paths:
         /nix/store/7iqiglqg566afnk5g1wkkgm3lnhlirs5-claude-code-2.1.29
```

I copied the attributes from `claude-code-bin` in Nixpkgs which follows the native distribution like in `llm-agents.nix` rather than `claude-code` which still builds from npm.

With this PR:

```
$ nix build -L github:Enzime/llm-agents.nix/push-qskpvwyrwwzq#packages.aarch64-darwin.claude-code
claude-code> Running phase: patchPhase
claude-code> Running phase: updateAutotoolsGnuConfigScriptsPhase
claude-code> Running phase: configurePhase
claude-code> no configure script, doing nothing
claude-code> Running phase: buildPhase
claude-code> no Makefile or custom buildPhase, doing nothing
claude-code> Running phase: installPhase
claude-code> Running phase: fixupPhase
claude-code> checking for references to /nix/var/nix/b/3pwggi54mci97zj7b0jzibgvah/ in /nix/store/lwk03f8c3lqvjqk25p82y4rxk9kpyn37-claude-code-2.1.29...
claude-code> patching script interpreter paths in /nix/store/lwk03f8c3lqvjqk25p82y4rxk9kpyn37-claude-code-2.1.29
```

## Test plan

- [x] `nix build .#<package>` succeeds
- [ ] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work
