### PR TITLE
claude-code: pass bubblewrap and socat under linux platforms

### DIFF
--- a/packages/claude-code/package.nix
+++ b/packages/claude-code/package.nix
@@ -5,6 +5,8 @@
   makeWrapper,
   wrapBuddy,
   versionCheckHook,
+  bubblewrap,
+  socat,
 }:
 
 let
@@ -53,6 +55,15 @@ stdenv.mkDerivation {
       --set DISABLE_NON_ESSENTIAL_MODEL_CALLS 1 \
       --set DISABLE_TELEMETRY 1 \
       --set DISABLE_INSTALLATION_CHECKS 1
+  ''
+  + lib.optionalString stdenv.hostPlatform.isLinux ''
+    wrapProgram $out/bin/claude \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          bubblewrap
+          socat
+        ]
+      }
   '';
 
   doInstallCheck = true;


### PR DESCRIPTION
## Summary

claude-code requires both bubblewrap and socat to be in the environment for its sandboxing logic to work correctly

## Test plan

- [x] `nix build .#<package>` succeeds

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
