### PR TITLE
happy-coder: source claude from PATH

### DIFF
--- a/packages/happy-coder/package.nix
+++ b/packages/happy-coder/package.nix
@@ -28,6 +28,22 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-DlUUAj5b47KFhUBsftLjxYJJxyCxW9/xfp3WUCCClDY=";
   };
 
+  # Fix Claude detection to check PATH first (supports Nix installations)
+  postPatch = ''
+        sed -i '/^function findGlobalClaudeCliPath() {$/,/Check npm global/{
+          /Check npm global/i\
+        // Check PATH first (supports Nix and other package managers)\
+        try {\
+            const claudePath = require("child_process").execSync("which claude 2>/dev/null", { encoding: "utf8" }).trim();\
+            if (claudePath && require("fs").existsSync(claudePath)) {\
+                return { path: claudePath, source: "PATH" };\
+            }\
+        } catch (e) {}\
+    \
+
+        }' scripts/claude_version_utils.cjs
+  '';
+
   nativeBuildInputs = [
     nodejs
     yarnConfigHook


### PR DESCRIPTION
By default it only looks at Claude from ~/.local/bin and other places.

## Summary

<!-- Briefly describe what this PR does -->

## Test plan

<!-- How did you test this change? -->

- [ ] `nix build .#<package>` succeeds
- [ ] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
