### PR TITLE
copilot-cli: fix OpenSSL certificate directory warning

### DIFF
--- a/packages/copilot-cli/package.nix
+++ b/packages/copilot-cli/package.nix
@@ -4,6 +4,7 @@
   fetchurl,
   makeWrapper,
   wrapBuddy,
+  cacert,
   nodejs_24,
   versionCheckHook,
 }:
@@ -29,7 +30,8 @@ stdenv.mkDerivation (finalAttrs: {
 
     mkdir -p $out/bin
     makeWrapper ${nodejs_24}/bin/node $out/bin/copilot \
-      --add-flags "$out/lib/${finalAttrs.pname}/index.js"
+      --add-flags "$out/lib/${finalAttrs.pname}/index.js" \
+      --set SSL_CERT_DIR "${cacert}/etc/ssl/certs"
 
     runHook postInstall
   '';


### PR DESCRIPTION
Node.js looks for certificates in OpenSSL's store path, which doesn't exist in Nix. Point SSL_CERT_DIR to cacert instead.

## Summary

<!-- Briefly describe what this PR does -->

## Test plan

<!-- How did you test this change? -->

- [ ] `nix build .#<package>` succeeds
- [ ] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
