### PR TITLE
vibe-kanban: extract virtuoso license key from upstream release

### DIFF
--- a/packages/vibe-kanban/hashes.json
+++ b/packages/vibe-kanban/hashes.json
@@ -3,5 +3,6 @@
   "tag": "v0.1.2-20260203101746",
   "hash": "sha256-rC9r9UPkI75vf4Fk1snBz5KDf/U8lw6XrO2nF8gplpo=",
   "cargoHash": "sha256-IIpLTlHfDhMTwaUwNEGECQXnsWmPpibt6FkO8smrnBA=",
-  "npmDepsHash": "sha256-wY/ATOO3OcUc72ScmHradTnwBG7PZOqIFrTdHSAAY+8="
+  "npmDepsHash": "sha256-wY/ATOO3OcUc72ScmHradTnwBG7PZOqIFrTdHSAAY+8=",
+  "releaseZipHash": "sha256-dDoRqox1WQF6zqUJg859/1USpEEQ/uLlPO5Q6DQmfyg="
 }


### PR DESCRIPTION
The react-virtuoso VirtuosoMessageList component requires a commercial license key that upstream bakes into their CI-built release artifacts. Without it, core UI components (log viewer, chat, process logs) render as license errors, making the package unusable.

Download upstream's release zip at build time and extract the key from the pre-built JS assets, then pass it to the Vite frontend build via VITE_PUBLIC_REACT_VIRTUOSO_LICENSE_KEY. This avoids storing the key in our repository while keeping it in sync with whatever upstream ships.

Closes #2399

## Summary

<!-- Briefly describe what this PR does -->

## Test plan

<!-- How did you test this change? -->

- [ ] `nix build .#<package>` succeeds
- [ ] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
