### PR TITLE
fix(claude-code): fix process name showing as .claude-wrapped_

### DIFF
--- a/packages/claude-code/package.nix
+++ b/packages/claude-code/package.nix
@@ -59,8 +59,7 @@ stdenv.mkDerivation {
       --set CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC 1 \
       --set DISABLE_NON_ESSENTIAL_MODEL_CALLS 1 \
       --set DISABLE_TELEMETRY 1 \
-      --set DISABLE_INSTALLATION_CHECKS 1 \
-      ${lib.optionalString stdenv.hostPlatform.isLinux "--prefix PATH : ${
+      --set DISABLE_INSTALLATION_CHECKS 1 ${lib.optionalString stdenv.hostPlatform.isLinux "--prefix PATH : ${
         lib.makeBinPath [
           bubblewrap
           socat


### PR DESCRIPTION
## Summary

- Consolidate two separate `wrapProgram` calls into one to eliminate double-wrapping on Linux
- Add `--argv0 claude` to explicitly preserve the process name through the wrapper

## Problem

On Linux, the `postFixup` phase called `wrapProgram` twice — once for environment variables and once for PATH (bubblewrap/socat). This caused Nix's `makeWrapper` to double-wrap the binary:

```
claude (wrapper 1, PATH) → .claude-wrapped_ (wrapper 2, env vars) → .claude-wrapped (ELF)
```

The process then showed as `.claude-wrapped_` in `ps`/`htop` because `exec -a "$0"` doesn't propagate through shebang boundaries — each intermediate bash wrapper resets `$0` to its own script path.

## Fix

Merge both `wrapProgram` calls into a single invocation and add `--argv0 claude`:

```
claude (single wrapper, env vars + PATH) → .claude-wrapped (ELF)
```

The wrapper now does `exec -a "claude" .claude-wrapped` instead of `exec -a "$0"`, ensuring the process name is always "claude" regardless of how the wrapper chain is invoked.

## Test plan

- [x] `nix build .#claude-code` succeeds
- [x] `claude --version` outputs correctly
- [x] Wrapper contains both env vars AND bubblewrap/socat PATH entries
- [x] Wrapper uses `exec -a "claude"` (not `exec -a "$0"`)
- [x] No `.claude-wrapped_` intermediate file in bin/