### PR TITLE
slack-mcp-server: init at 1.1.28

### DIFF
--- a/packages/slack-mcp-server/default.nix
+++ b/packages/slack-mcp-server/default.nix
@@ -1,0 +1,5 @@
+{
+  pkgs,
+  ...
+}:
+pkgs.callPackage ./package.nix { }

--- a/packages/slack-mcp-server/hashes.json
+++ b/packages/slack-mcp-server/hashes.json
@@ -1,0 +1,5 @@
+{
+  "version": "1.1.28",
+  "hash": "sha256-tA0JzWaMtYF0DC5xUm+hGAVEPvxBTMLau5lrhOQU9gU=",
+  "vendorHash": "sha256-CEg7OHriwCD1XM4lOCNcIPiMXnHuerramWp4//9roOo="
+}

--- a/packages/slack-mcp-server/package.nix
+++ b/packages/slack-mcp-server/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  go_1_24,
+}:
+
+let
+  versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
+  inherit (versionData) version hash vendorHash;
+
+  src = fetchFromGitHub {
+    owner = "korotovsky";
+    repo = "slack-mcp-server";
+    rev = "v${version}";
+    inherit hash;
+  };
+in
+(buildGoModule.override { go = go_1_24; }) {
+  pname = "slack-mcp-server";
+  inherit version vendorHash src;
+
+  subPackages = [ "cmd/slack-mcp-server" ];
+
+  doCheck = false;
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  passthru.category = "MCP Servers";
+
+  meta = {
+    description = "MCP server for Slack with stealth mode, OAuth, DMs, and smart history";
+    homepage = "https://github.com/korotovsky/slack-mcp-server";
+    license = lib.licenses.mit;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    maintainers = with lib.maintainers; [ garbas ];
+    mainProgram = "slack-mcp-server";
+  };
+}


### PR DESCRIPTION
## Summary

- Adds [slack-mcp-server](https://github.com/korotovsky/slack-mcp-server) package (v1.1.28)
- Builds from source using `buildGoModule` with Go 1.24
- Supports stealth mode (browser tokens), OAuth user tokens, and bot tokens
- Updates handled by `nix-update`