### PR TITLE
beads-rust: init at 0.1.13

### DIFF
--- a/packages/beads-rust/default.nix
+++ b/packages/beads-rust/default.nix
@@ -1,8 +1,5 @@
 {
   pkgs,
-  perSystem,
   ...
 }:
-pkgs.callPackage ./package.nix {
-  inherit (perSystem.self) wrapBuddy;
-}
+pkgs.callPackage ./package.nix { }

--- a/packages/beads-rust/hashes.json
+++ b/packages/beads-rust/hashes.json
@@ -1,8 +1,0 @@
-{
-  "version": "0.1.13",
-  "hashes": {
-    "x86_64-linux": "sha256-A9TcfpXMf3yy+QnCnfL+zXIabkG1NKv9XkhLAwlQQ2c=",
-    "x86_64-darwin": "sha256-uvlSRW+cz5DX/uxm7pT/0F9NNSg/urOtdiWyRQ68gUA=",
-    "aarch64-darwin": "sha256-2a7E2PHCJeD9Iro+ABLj1rFDqAOGKULsHwFjn6v5UVg="
-  }
-}


### PR DESCRIPTION
## Summary

- Adds `beads-rust` (`br`), a fast Rust port of Steve Yegge's beads — a local-first, non-invasive issue tracker for git repositories
- Source: [Dicklesworthstone/beads_rust](https://github.com/Dicklesworthstone/beads_rust)
- Packaged as binary distribution from GitHub releases
- Platforms: x86_64-linux, x86_64-darwin, aarch64-darwin
- Category: Workflow & Project Management (alongside existing `beads` package)

## Differences from `beads`

The existing `beads` package builds the original Go implementation (`steveyegge/beads`, binary: `bd`). This adds the Rust port (`Dicklesworthstone/beads_rust`, binary: `br`) which provides the same functionality with improved performance.

## Test plan

- [ ] `nix build .#beads-rust` on aarch64-darwin
- [ ] `versionCheckHook` passes (`br --version` outputs `br 0.1.13`)
- [ ] Binary runs correctly: `nix run .#beads-rust -- --help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)