### PR TITLE
get-shit-done: init at 1.18.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>get-shit-done</strong> - Meta-prompting, context engineering and spec-driven development system for Claude Code</summary>
+
+- **Source**: source
+- **License**: MIT
+- **Homepage**: https://github.com/gsd-build/get-shit-done
+- **Usage**: `nix run github:numtide/llm-agents.nix#get-shit-done -- --help`
+- **Nix**: [packages/get-shit-done/package.nix](packages/get-shit-done/package.nix)
+
+</details>
+<details>
 <summary><strong>openspec</strong> - Spec-driven development for AI coding assistants</summary>
 
 - **Source**: bytecode

--- a/packages/get-shit-done/default.nix
+++ b/packages/get-shit-done/default.nix
@@ -1,0 +1,5 @@
+{
+  pkgs,
+  ...
+}:
+pkgs.callPackage ./package.nix { }

--- a/packages/get-shit-done/package.nix
+++ b/packages/get-shit-done/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+}:
+
+buildNpmPackage rec {
+  pname = "get-shit-done";
+  version = "1.18.0";
+
+  src = fetchFromGitHub {
+    owner = "gsd-build";
+    repo = "get-shit-done";
+    rev = "v${version}";
+    hash = "sha256-PbvmJkFv1NHd7pc+N4lVh/8ZiQHuPpUpCZLQIX3VZxs=";
+  };
+
+  npmDepsHash = "sha256-GokUAV6utbgTzoj3pLb1OWP+MupVtOYzaO0peka6V1s=";
+
+  npmBuildScript = "build:hooks";
+
+  dontNpmInstall = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/node_modules/get-shit-done-cc/hooks
+    cp -r bin commands get-shit-done agents scripts package.json $out/lib/node_modules/get-shit-done-cc/
+    cp -r hooks/dist $out/lib/node_modules/get-shit-done-cc/hooks/
+
+    mkdir -p $out/bin
+    ln -s $out/lib/node_modules/get-shit-done-cc/bin/install.js $out/bin/get-shit-done
+    chmod +x $out/lib/node_modules/get-shit-done-cc/bin/install.js
+
+    runHook postInstall
+  '';
+
+  passthru.category = "Workflow & Project Management";
+
+  meta = with lib; {
+    description = "Meta-prompting, context engineering and spec-driven development system for Claude Code";
+    homepage = "https://github.com/gsd-build/get-shit-done";
+    license = licenses.mit;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    maintainers = with maintainers; [ ];
+    mainProgram = "get-shit-done";
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
## Summary

<!-- Briefly describe what this PR does -->
add get-shit-done. A workflow, which is kinda a mixture of [ralph](https://ghuntley.com/ralph/) and openspec

## Test plan

<!-- How did you test this change? -->

- [x] `nix build .#<package>` succeeds
- [ ] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
