### PR TITLE
feat(auto-claude): adding auto-claude tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 ### Claude Code Ecosystem
 
 <details>
+<summary><strong>auto-claude</strong> - Autonomous multi-agent coding framework powered by Claude AI</summary>
+
+- **Source**: binary
+- **License**: unfree
+- **Homepage**: https://github.com/AndyMik90/Auto-Claude
+- **Usage**: `nix run github:numtide/llm-agents.nix#auto-claude -- --help`
+- **Nix**: [packages/auto-claude/package.nix](packages/auto-claude/package.nix)
+
+</details>
+<details>
 <summary><strong>catnip</strong> - Developer environment that's like catnip for agentic programming</summary>
 
 - **Source**: binary

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -32,6 +32,11 @@ inputs.nixpkgs.lib.extend (
         githubId = 198010;
         name = "Charles Swanberg";
       };
+      xorilog = {
+        github = "xorilog";
+        githubId = 5818406;
+        name = "Christophe Boucharlat";
+      };
     };
   }
 )

--- a/packages/auto-claude/default.nix
+++ b/packages/auto-claude/default.nix
@@ -1,0 +1,6 @@
+{
+  pkgs,
+  flake,
+  ...
+}:
+pkgs.callPackage ./package.nix { inherit flake; }

--- a/packages/auto-claude/hashes.json
+++ b/packages/auto-claude/hashes.json
@@ -1,0 +1,8 @@
+{
+  "version": "2.7.5",
+  "hashes": {
+    "x86_64-linux": "sha256-8UOmxlAROJUPNDZlC4Lv1GvLf0yV3ZnueWNXxtY3who=",
+    "x86_64-darwin": "sha256-bFBtzcXUSNpL7p+AWx1HJ/S/+lacoDbxmBVI0xQV3vc=",
+    "aarch64-darwin": "sha256-hxsMMXBliOJdmgK1n5LG32XAL6U8WrA34Rm7GrFx9DU="
+  }
+}

--- a/packages/auto-claude/package.nix
+++ b/packages/auto-claude/package.nix
@@ -1,0 +1,123 @@
+{
+  lib,
+  flake,
+  stdenv,
+  fetchurl,
+  appimageTools,
+  unzip,
+  makeWrapper,
+}:
+
+let
+  versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
+  inherit (versionData) version hashes;
+
+  pname = "auto-claude";
+
+  platform = stdenv.hostPlatform.system;
+
+  sources = {
+    x86_64-linux = {
+      url = "https://github.com/AndyMik90/Auto-Claude/releases/download/v${version}/Auto-Claude-${version}-linux-x86_64.AppImage";
+      hash = hashes.x86_64-linux;
+    };
+    x86_64-darwin = {
+      url = "https://github.com/AndyMik90/Auto-Claude/releases/download/v${version}/Auto-Claude-${version}-darwin-x64.zip";
+      hash = hashes.x86_64-darwin;
+    };
+    aarch64-darwin = {
+      url = "https://github.com/AndyMik90/Auto-Claude/releases/download/v${version}/Auto-Claude-${version}-darwin-arm64.zip";
+      hash = hashes.aarch64-darwin;
+    };
+  };
+
+  src = fetchurl sources.${platform} or (throw "Unsupported system: ${platform}");
+
+  meta = with lib; {
+    description = "Autonomous multi-agent coding framework powered by Claude AI";
+    homepage = "https://github.com/AndyMik90/Auto-Claude";
+    changelog = "https://github.com/AndyMik90/Auto-Claude/releases/tag/v${version}";
+    license = licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with flake.lib.maintainers; [ xorilog ];
+    mainProgram = "auto-claude";
+    platforms = [
+      "x86_64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+  };
+
+  linux = appimageTools.wrapType2 {
+    inherit
+      pname
+      version
+      src
+      meta
+      ;
+
+    extraInstallCommands =
+      let
+        appimageContents = appimageTools.extractType2 { inherit pname version src; };
+      in
+      ''
+        # Install desktop file if present
+        if [ -f "${appimageContents}/auto-claude.desktop" ]; then
+          install -Dm644 ${appimageContents}/auto-claude.desktop $out/share/applications/auto-claude.desktop
+          substituteInPlace $out/share/applications/auto-claude.desktop \
+            --replace-fail 'Exec=AppRun' 'Exec=auto-claude'
+        fi
+
+        # Install icons if they exist
+        for size in 16 32 48 64 128 256 512; do
+          if [ -f "${appimageContents}/usr/share/icons/hicolor/''${size}x''${size}/apps/auto-claude.png" ]; then
+            install -Dm644 "${appimageContents}/usr/share/icons/hicolor/''${size}x''${size}/apps/auto-claude.png" \
+              "$out/share/icons/hicolor/''${size}x''${size}/apps/auto-claude.png"
+          fi
+        done
+
+        # Fallback: install main icon if present
+        if [ -f "${appimageContents}/auto-claude.png" ]; then
+          install -Dm644 "${appimageContents}/auto-claude.png" "$out/share/icons/hicolor/256x256/apps/auto-claude.png"
+        fi
+      '';
+
+    passthru.category = "Claude Code Ecosystem";
+  };
+
+  darwin = stdenv.mkDerivation {
+    inherit
+      pname
+      version
+      src
+      meta
+      ;
+
+    nativeBuildInputs = [
+      unzip
+      makeWrapper
+    ];
+
+    unpackPhase = ''
+      runHook preUnpack
+      unzip -q $src
+      runHook postUnpack
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/Applications
+      cp -r "Auto-Claude.app" $out/Applications/
+
+      # Create a wrapper script in bin
+      mkdir -p $out/bin
+      makeWrapper "$out/Applications/Auto-Claude.app/Contents/MacOS/Auto-Claude" $out/bin/auto-claude
+
+      runHook postInstall
+    '';
+
+    passthru.category = "Claude Code Ecosystem";
+  };
+in
+if stdenv.hostPlatform.isLinux then linux else darwin

--- a/packages/auto-claude/update.py
+++ b/packages/auto-claude/update.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env nix
+#! nix shell --inputs-from .# nixpkgs#python3 --command python3
+
+"""Update script for auto-claude package."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+
+from updater import (
+    calculate_platform_hashes,
+    fetch_github_latest_release,
+    load_hashes,
+    save_hashes,
+    should_update,
+)
+
+HASHES_FILE = Path(__file__).parent / "hashes.json"
+
+PLATFORMS = {
+    "x86_64-linux": "linux-x86_64.AppImage",
+    "x86_64-darwin": "darwin-x64.zip",
+    "aarch64-darwin": "darwin-arm64.zip",
+}
+
+
+def main() -> None:
+    """Update the auto-claude package."""
+    data = load_hashes(HASHES_FILE)
+    current = data["version"]
+    latest = fetch_github_latest_release("AndyMik90", "Auto-Claude")
+
+    print(f"Current: {current}, Latest: {latest}")
+
+    if not should_update(current, latest):
+        print("Already up to date")
+        return
+
+    url_template = f"https://github.com/AndyMik90/Auto-Claude/releases/download/v{latest}/Auto-Claude-{latest}-{{platform}}"
+    hashes = calculate_platform_hashes(url_template, PLATFORMS)
+
+    save_hashes(HASHES_FILE, {"version": latest, "hashes": hashes})
+    print(f"Updated to {latest}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

<!-- Briefly describe what this PR does -->

This PR adds https://github.com/AndyMik90/Auto-Claude tool
> Autonomous multi-agent coding framework that plans, builds, and validates software for you.

I have an issue as there is no released binary for `aarch64-linux` architecture, i do not know if this is blocking or if i should find an other way to do it... please tell me as i am pretty new in nix !

Also the binary does not support `--version`, i did not used versionCheckHook or versionCheckHomeHook...
## Test plan

<!-- How did you test this change? -->

- [x] `nix fmt` succeeds.
- [x] `nix build --accept-flake-config .#auto-claude` succeeds.
- [x] Package updates via custom `update.py` works

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
