### PR TITLE
default: add fzf-based launcher for discovering packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -653,19 +653,22 @@ Alternatively, use the overlay to access packages under the `llm-agents` namespa
 
 ### Try Without Installing
 
+Browse all available tools with the interactive launcher:
+
 ```bash
-# Try Claude Code
+nix run github:numtide/llm-agents.nix
+```
+
+This opens an fzf picker listing every package with its description.
+Select one and it will be run via `nix run`.
+
+Or run a specific tool directly:
+
+```bash
 nix run github:numtide/llm-agents.nix#claude-code
-
-# Try OpenCode
 nix run github:numtide/llm-agents.nix#opencode
-
-# Try Gemini CLI
 nix run github:numtide/llm-agents.nix#gemini-cli
-
-# Try Qwen Code
 nix run github:numtide/llm-agents.nix#qwen-code
-
 # etc...
 ```
 

--- a/packages/default/default.nix
+++ b/packages/default/default.nix
@@ -1,0 +1,19 @@
+{
+  pkgs,
+  perSystem,
+  ...
+}:
+let
+  allPackages = perSystem.self;
+
+  # Filter to visible, runnable packages
+  visibleNames = builtins.filter (
+    name: name != "default" && !(allPackages.${name}.passthru.hideFromDocs or false)
+  ) (builtins.attrNames allPackages);
+
+  # Build "name\tdescription" lines
+  packageLines = map (name: "${name}\t${allPackages.${name}.meta.description or ""}") visibleNames;
+
+  packageList = builtins.concatStringsSep "\n" packageLines;
+in
+pkgs.callPackage ./package.nix { inherit packageList; }

--- a/packages/default/package.nix
+++ b/packages/default/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  writeShellApplication,
+  fzf,
+  nix,
+  util-linux,
+  packageList,
+}:
+
+let
+  packageListFile = builtins.toFile "llm-agents-packages.tsv" packageList;
+in
+writeShellApplication {
+  name = "llm-agents-launcher";
+
+  runtimeInputs = [
+    fzf
+    nix
+    util-linux # column
+  ];
+
+  text = ''
+    # Format for fzf: "name  description" (tab-aligned)
+    entries=$(column -t -s $'\t' < "${packageListFile}")
+
+    if [[ -z $entries ]]; then
+      echo "No packages found" >&2
+      exit 1
+    fi
+
+    # Let user pick with fzf
+    selected=$(echo "$entries" | fzf \
+      --header="Select an AI tool to run (ESC to cancel)" \
+      --preview-window=hidden \
+      --no-multi \
+      --height=~40% \
+      --layout=reverse) || exit 0
+
+    # Extract package name (first word)
+    pkg_name=$(echo "$selected" | awk '{print $1}')
+
+    if [[ -z $pkg_name ]]; then
+      exit 0
+    fi
+
+    echo "→ Running: nix run github:numtide/llm-agents.nix#$pkg_name"
+    exec nix run "github:numtide/llm-agents.nix#$pkg_name"
+  '';
+
+  meta = with lib; {
+    description = "Interactive fzf launcher for llm-agents.nix packages";
+    license = licenses.mit;
+    mainProgram = "llm-agents-launcher";
+    platforms = platforms.all;
+  };
+
+  passthru = {
+    hideFromDocs = true;
+  };
+}


### PR DESCRIPTION
With 60+ packages in the repo, there is no quick way to browse and try
them interactively. Make the default package an fzf launcher so that
a bare "nix run github:numtide/llm-agents.nix" lets users pick any
tool from a searchable list and runs it immediately.

The package list is pre-computed at build time from perSystem to avoid
runtime nix eval overhead. Launched packages are fetched via the
github: flake ref so binary cache hits work out of the box.
