### PR TITLE
gemini-cli: preserve PATH during version check for sysctl stub

### DIFF
--- a/packages/gemini-cli/package.nix
+++ b/packages/gemini-cli/package.nix
@@ -142,6 +142,10 @@ buildNpmPackage (finalAttrs: {
     # module resolves the native architecture without pulling in system_cmds.
     (writeShellScriptBin "sysctl" "echo 0")
   ];
+  # versionCheckHook runs with --ignore-environment by default, stripping PATH.
+  # We need PATH preserved so the sysctl stub (and node itself) can be found
+  # by child processes spawned during `gemini --version`.
+  versionCheckKeepEnvironment = "PATH";
 
   passthru = {
     category = "AI Coding Agents";


### PR DESCRIPTION
The sysctl stub added in #2474 was never reachable because versionCheckHook runs with `env --ignore-environment`, stripping PATH entirely. Set versionCheckKeepEnvironment so the stub (and any other commands spawned by node child processes) can actually be found.

Fixes #2401

## Summary

<!-- Briefly describe what this PR does -->

## Test plan

<!-- How did you test this change? -->

- [ ] `nix build .#<package>` succeeds
- [ ] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
