### PR TITLE
mcporter: init at 0.7.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,6 +579,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>mcporter</strong> - TypeScript runtime and CLI for the Model Context Protocol</summary>
+
+- **Source**: source
+- **License**: MIT
+- **Homepage**: https://github.com/steipete/mcporter
+- **Usage**: `nix run github:numtide/llm-agents.nix#mcporter -- --help`
+- **Nix**: [packages/mcporter/package.nix](packages/mcporter/package.nix)
+
+</details>
+<details>
 <summary><strong>openclaw</strong> - Your own personal AI assistant. Any OS. Any Platform. The lobster way</summary>
 
 - **Source**: source

--- a/packages/mcporter/default.nix
+++ b/packages/mcporter/default.nix
@@ -1,0 +1,8 @@
+{
+  pkgs,
+  perSystem,
+  ...
+}:
+pkgs.callPackage ./package.nix {
+  inherit (perSystem.self) versionCheckHomeHook;
+}

--- a/packages/mcporter/package.nix
+++ b/packages/mcporter/package.nix
@@ -1,0 +1,81 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  makeWrapper,
+  nodejs,
+  pnpm,
+  pnpmConfigHook,
+  versionCheckHook,
+  versionCheckHomeHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "mcporter";
+  version = "0.7.3";
+
+  src = fetchFromGitHub {
+    owner = "steipete";
+    repo = "mcporter";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-x/2Ln6kohj59RSJgctWlYKckmGbWjY2ryPaLhoj0Q48=";
+  };
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-0nc+jYANd95/R+BrkGRHcdqw9/RqMja88qkVvHtj1W4=";
+    fetcherVersion = 2;
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+    nodejs
+    pnpm
+    pnpmConfigHook
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    pnpm build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,lib/mcporter}
+
+    # Prune dev dependencies to reduce closure size
+    pnpm prune --prod
+
+    cp -r dist $out/lib/mcporter/
+    cp -r node_modules $out/lib/mcporter/
+    cp package.json $out/lib/mcporter/
+
+    makeWrapper ${nodejs}/bin/node $out/bin/mcporter \
+      --add-flags "$out/lib/mcporter/dist/cli.js"
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    versionCheckHomeHook
+  ];
+
+  passthru.category = "Utilities";
+
+  meta = {
+    description = "TypeScript runtime and CLI for the Model Context Protocol";
+    homepage = "https://github.com/steipete/mcporter";
+    changelog = "https://github.com/steipete/mcporter/releases";
+    license = lib.licenses.mit;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    platforms = lib.platforms.all;
+    mainProgram = "mcporter";
+  };
+})

--- a/scripts/generate-package-docs.py
+++ b/scripts/generate-package-docs.py
@@ -78,6 +78,7 @@ CATEGORY_ORDER = [
     "AI Coding Agents",
     "Claude Code Ecosystem",
     "ACP Ecosystem",
+    "MCP",
     "Usage Analytics",
     "Workflow & Project Management",
     "Code Review",


### PR DESCRIPTION
Add mcporter, a TypeScript runtime and CLI for the Model Context Protocol.
## Summary

<!-- Briefly describe what this PR does -->

## Test plan

<!-- How did you test this change? -->

- [ ] `nix build .#<package>` succeeds
- [ ] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
