### PR TITLE
omp: init at 12.9.0

### DIFF
--- a/packages/omp/default.nix
+++ b/packages/omp/default.nix
@@ -1,0 +1,1 @@
+{ pkgs }: pkgs.callPackage ./package.nix { }

--- a/packages/omp/hashes.json
+++ b/packages/omp/hashes.json
@@ -1,0 +1,9 @@
+{
+  "version": "12.9.0",
+  "hashes": {
+    "aarch64-darwin": "sha256-vFq9NOaPha3tsEjLYdKkJkhQEl3/xSqkoxxRlkw634w=",
+    "x86_64-darwin": "sha256-AOcQt6GP8l1pi4G51CVskXMP7S4jJhho8LwRNrvUO68=",
+    "aarch64-linux": "sha256-Vw9LhrUweIEsc22jZu0EOrMKY5zGa2nPdjxra3yX2rw=",
+    "x86_64-linux": "sha256-h1pOclgl/+j4B/1dOj+5wwxv6PD4zGCr3YzgQeij01M="
+  }
+}

--- a/packages/omp/package.nix
+++ b/packages/omp/package.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  makeWrapper,
+  autoPatchelfHook,
+  stdenv,
+}:
+
+let
+  versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
+  inherit (versionData) version hashes;
+
+  platformMap = {
+    x86_64-linux = "omp-linux-x64";
+    aarch64-linux = "omp-linux-arm64";
+    x86_64-darwin = "omp-darwin-x64";
+    aarch64-darwin = "omp-darwin-arm64";
+  };
+
+  platform = stdenvNoCC.hostPlatform.system;
+  platformBinary = platformMap.${platform} or (throw "Unsupported system: ${platform}");
+in
+stdenvNoCC.mkDerivation {
+  pname = "omp";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://github.com/can1357/oh-my-pi/releases/download/v${version}/${platformBinary}";
+    hash = hashes.${platform};
+  };
+
+  dontUnpack = true;
+  dontStrip = true;
+
+  nativeBuildInputs = [
+    makeWrapper
+  ]
+  ++ lib.optionals stdenvNoCC.hostPlatform.isLinux [
+    autoPatchelfHook
+  ];
+
+  buildInputs = lib.optionals stdenvNoCC.hostPlatform.isLinux [
+    stdenv.cc.cc.lib
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp $src $out/bin/omp
+    chmod +x $out/bin/omp
+
+    wrapProgram $out/bin/omp \
+      --set PI_SKIP_VERSION_CHECK 1
+
+    runHook postInstall
+  '';
+
+  passthru.category = "AI Coding Agents";
+
+  meta = with lib; {
+    description = "A terminal-based coding agent with multi-model support (binary release)";
+    homepage = "https://github.com/can1357/oh-my-pi";
+    changelog = "https://github.com/can1357/oh-my-pi/releases/tag/v${version}";
+    license = licenses.mit;
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    maintainers = with maintainers; [ aldoborrero ];
+    platforms = builtins.attrNames platformMap;
+    mainProgram = "omp";
+  };
+}

--- a/packages/omp/update.py
+++ b/packages/omp/update.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env nix
+#! nix shell --inputs-from .# nixpkgs#python3 --command python3
+
+"""Update script for omp (oh-my-pi) package."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+
+from updater import (
+    calculate_platform_hashes,
+    fetch_github_latest_release,
+    load_hashes,
+    save_hashes,
+    should_update,
+)
+
+HASHES_FILE = Path(__file__).parent / "hashes.json"
+
+PLATFORMS = {
+    "x86_64-linux": "omp-linux-x64",
+    "aarch64-linux": "omp-linux-arm64",
+    "x86_64-darwin": "omp-darwin-x64",
+    "aarch64-darwin": "omp-darwin-arm64",
+}
+
+
+def main() -> None:
+    """Update the omp package."""
+    data = load_hashes(HASHES_FILE)
+    current = data["version"]
+    latest = fetch_github_latest_release("can1357", "oh-my-pi")
+
+    print(f"Current: {current}, Latest: {latest}")
+
+    if not should_update(current, latest):
+        print("Already up to date")
+        return
+
+    url_template = (
+        f"https://github.com/can1357/oh-my-pi/releases/download/v{latest}/{{platform}}"
+    )
+    hashes = calculate_platform_hashes(url_template, PLATFORMS)
+
+    save_hashes(HASHES_FILE, {"version": latest, "hashes": hashes})
+    print(f"Updated to {latest}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Add omp (a `pi-mono`) fork.

## Test plan

<!-- How did you test this change? -->

- [ ] `nix build .#<package>` succeeds
- [x] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
