### PR TITLE
ci: run update every 2 hours

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,8 +1,8 @@
 name: Update Dependencies
 on:
   schedule:
-    # Run twice daily at 2 AM and 2 PM UTC
-    - cron: '0 2,14 * * *'
+    # Run every 2 hours
+    - cron: '0 */2 * * *'
   workflow_dispatch:
     inputs:
       packages:


### PR DESCRIPTION
## Summary

Run the update CI workflow every two hours. Not sure if there was a reason for just doing it twice daily? The job is relatively fast, and it's an open-source repo so limits shouldn't be a problem.