### PR TITLE
rtk: init at 0.22.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -628,6 +628,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 - **Nix**: [packages/qmd/package.nix](packages/qmd/package.nix)
 
 </details>
+<details>
+<summary><strong>rtk</strong> - CLI proxy that reduces LLM token consumption by 60-90% on common dev commands</summary>
+
+- **Source**: source
+- **License**: MIT
+- **Homepage**: https://github.com/rtk-ai/rtk
+- **Usage**: `nix run github:numtide/llm-agents.nix#rtk -- --help`
+- **Nix**: [packages/rtk/package.nix](packages/rtk/package.nix)
+
+</details>
 <!-- END GENERATED PACKAGE DOCS -->
 
 ## Installation

--- a/packages/rtk/default.nix
+++ b/packages/rtk/default.nix
@@ -1,0 +1,1 @@
+{ pkgs }: pkgs.callPackage ./package.nix { }

--- a/packages/rtk/package.nix
+++ b/packages/rtk/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  makeWrapper,
+  jq,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "rtk";
+  version = "0.22.1";
+
+  src = fetchFromGitHub {
+    owner = "rtk-ai";
+    repo = "rtk";
+    rev = "v${version}";
+    hash = "sha256-6dkBuZBUlFujffn4L3CDIqERKMCwH0gTt2ASOsd4wPs=";
+  };
+
+  cargoHash = "sha256-tp7sW9QhalG4ZDQnPyf7ZPp+GoN5W1uL8KJPDaoMPY4=";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  doCheck = false;
+
+  postInstall = ''
+    install -Dm755 $src/hooks/rtk-rewrite.sh $out/libexec/rtk/hooks/rtk-rewrite.sh
+    wrapProgram $out/libexec/rtk/hooks/rtk-rewrite.sh \
+      --prefix PATH : ${lib.makeBinPath [ jq ]}:$out/bin
+  '';
+
+  passthru.category = "Utilities";
+
+  meta = with lib; {
+    description = "CLI proxy that reduces LLM token consumption by 60-90% on common dev commands";
+    homepage = "https://github.com/rtk-ai/rtk";
+    changelog = "https://github.com/rtk-ai/rtk/releases/tag/v${version}";
+    license = licenses.mit;
+    sourceProvenance = with sourceTypes; [ fromSource ];
+    maintainers = with maintainers; [ vizid ];
+    mainProgram = "rtk";
+    platforms = platforms.unix;
+  };
+}


### PR DESCRIPTION
## Summary

<!-- Briefly describe what this PR does -->
https://github.com/rtk-ai/rtk
rtk filters and compresses command outputs before they reach your LLM context, saving 60-90% of tokens on common operations.

## Test plan

<!-- How did you test this change? -->

- [x] `nix build .#<package>` succeeds
- [x] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
