### PR TITLE
zeroclaw, picoclaw: init at 0.1.0, 0.1.2

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -37,6 +37,11 @@ inputs.nixpkgs.lib.extend (
         githubId = 5818406;
         name = "Christophe Boucharlat";
       };
+      commandodev = {
+        github = "commandodev";
+        githubId = 87764;
+        name = "Ben Ford";
+      };
     };
   }
 )

--- a/packages/picoclaw/default.nix
+++ b/packages/picoclaw/default.nix
@@ -1,8 +1,10 @@
 {
   pkgs,
+  flake,
   perSystem,
   ...
 }:
 pkgs.callPackage ./package.nix {
+  inherit flake;
   inherit (perSystem.self) versionCheckHomeHook;
 }

--- a/packages/picoclaw/package.nix
+++ b/packages/picoclaw/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  flake,
   buildGoModule,
   fetchFromGitHub,
   go_1_25,
@@ -53,6 +54,7 @@ buildGoModule.override { go = go_1_25; } rec {
     changelog = "https://github.com/sipeed/picoclaw/releases";
     license = lib.licenses.mit;
     sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    maintainers = with flake.lib.maintainers; [ commandodev ];
     mainProgram = "picoclaw";
     platforms = lib.platforms.unix;
   };

--- a/packages/zeroclaw/default.nix
+++ b/packages/zeroclaw/default.nix
@@ -1,8 +1,10 @@
 {
   pkgs,
+  flake,
   perSystem,
   ...
 }:
 pkgs.callPackage ./package.nix {
+  inherit flake;
   inherit (perSystem.self) versionCheckHomeHook;
 }

--- a/packages/zeroclaw/package.nix
+++ b/packages/zeroclaw/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  flake,
   rustPlatform,
   fetchFromGitHub,
   versionCheckHook,
@@ -36,6 +37,7 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/zeroclaw-labs/zeroclaw/releases";
     license = lib.licenses.mit;
     sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    maintainers = with flake.lib.maintainers; [ commandodev ];
     mainProgram = "zeroclaw";
     platforms = lib.platforms.unix;
   };


### PR DESCRIPTION
## Summary
- Add **zeroclaw** package (Rust-based AI assistant) at version 0.1.0 from [zeroclaw-labs/zeroclaw](https://github.com/zeroclaw-labs/zeroclaw)
- Add **picoclaw** package (Go-based AI assistant) at version 0.1.2 from [sipeed/picoclaw](https://github.com/sipeed/picoclaw)

## Test plan
- [x] `nix build .#zeroclaw` succeeds
- [x] `nix run .#zeroclaw -- --version` outputs `zeroclaw 0.1.0`
- [x] `nix build .#picoclaw` succeeds
- [x] `nix run .#picoclaw -- --version` outputs `🦞 picoclaw 0.1.2`
- [x] `nix fmt` passes with no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)