### PR TITLE
picoclaw: init at 0.1.2

### DIFF
--- a/packages/picoclaw/default.nix
+++ b/packages/picoclaw/default.nix
@@ -1,0 +1,8 @@
+{
+  pkgs,
+  perSystem,
+  ...
+}:
+pkgs.callPackage ./package.nix {
+  inherit (perSystem.self) versionCheckHomeHook;
+}

--- a/packages/picoclaw/package.nix
+++ b/packages/picoclaw/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  go_1_25,
+  versionCheckHook,
+  versionCheckHomeHook,
+}:
+
+buildGoModule.override { go = go_1_25; } rec {
+  pname = "picoclaw";
+  version = "0.1.2";
+
+  src = fetchFromGitHub {
+    owner = "sipeed";
+    repo = "picoclaw";
+    tag = "v${version}";
+    hash = "sha256-2q/BQmZaSh88kwquiQlWGS36MVFWWdUzsMxGp4cAMiE=";
+  };
+
+  vendorHash = "sha256-3kDU3pbcz+2cd36/bcbdU/IXTAeJosBZ+syUQqO2bls=";
+
+  postPatch = ''
+    # Relax Go version requirement to match nixpkgs go_1_25
+    substituteInPlace go.mod --replace-fail 'go 1.25.7' 'go 1.25.5'
+
+    # go:embed in cmd_onboard.go expects a workspace directory copied by go:generate
+    cp -r workspace cmd/picoclaw/workspace
+  '';
+
+  subPackages = [ "cmd/picoclaw" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${version}"
+  ];
+
+  # Tests require runtime configuration and network access
+  doCheck = false;
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    versionCheckHomeHook
+  ];
+
+  passthru.category = "AI Coding Agents";
+
+  meta = {
+    description = "Tiny, fast, and deployable anywhere — automate the mundane, unleash your creativity";
+    homepage = "https://picoclaw.io";
+    changelog = "https://github.com/sipeed/picoclaw/releases";
+    license = lib.licenses.mit;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    mainProgram = "picoclaw";
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
## Summary
- Add picoclaw package (Go-based AI assistant) at version 0.1.2
- Source: [sipeed/picoclaw](https://github.com/sipeed/picoclaw)
- Built with `buildGoModule` using `go_1_25`, version injected via ldflags
- Patches: relaxes Go version requirement (1.25.7 → 1.25.5), copies embedded workspace directory for `go:embed`

## Test plan
- [x] `nix build .#picoclaw` succeeds
- [x] `nix run .#picoclaw -- --version` outputs `🦞 picoclaw 0.1.2`
- [x] `nix fmt` passes with no changes
- [x] Version interpolated via `rec` for `nix-update` compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)