### PR TITLE
Separate general AI assistants from coding agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,7 @@ meta = { ... };
 Available categories (in display order):
 
 - **AI Coding Agents** - Main AI coding assistants (claude-code, codex, gemini-cli, etc.)
+- **AI Assistants** - General-purpose AI assistants not focused on coding (localgpt, openclaw, etc.)
 - **Claude Code Ecosystem** - Tools specifically for Claude Code (claudebox, catnip, etc.)
 - **ACP Ecosystem** - Agent Control Protocol implementations (claude-code-acp, codex-acp, agent-client-protocol)
 - **Usage Analytics** - Usage tracking and analysis tools (ccusage and variants)

--- a/README.md
+++ b/README.md
@@ -230,6 +230,49 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 
+### AI Assistants
+
+<details>
+<summary><strong>localgpt</strong> - Local AI assistant with persistent markdown memory, autonomous tasks, and semantic search</summary>
+
+- **Source**: source
+- **License**: Apache-2.0
+- **Homepage**: https://github.com/localgpt-app/localgpt
+- **Usage**: `nix run github:numtide/llm-agents.nix#localgpt -- --help`
+- **Nix**: [packages/localgpt/package.nix](packages/localgpt/package.nix)
+
+</details>
+<details>
+<summary><strong>openclaw</strong> - Your own personal AI assistant. Any OS. Any Platform. The lobster way</summary>
+
+- **Source**: source
+- **License**: MIT
+- **Homepage**: https://openclaw.ai
+- **Usage**: `nix run github:numtide/llm-agents.nix#openclaw -- --help`
+- **Nix**: [packages/openclaw/package.nix](packages/openclaw/package.nix)
+
+</details>
+<details>
+<summary><strong>picoclaw</strong> - Tiny, fast, and deployable anywhere — automate the mundane, unleash your creativity</summary>
+
+- **Source**: source
+- **License**: MIT
+- **Homepage**: https://picoclaw.io
+- **Usage**: `nix run github:numtide/llm-agents.nix#picoclaw -- --help`
+- **Nix**: [packages/picoclaw/package.nix](packages/picoclaw/package.nix)
+
+</details>
+<details>
+<summary><strong>zeroclaw</strong> - Fast, small, and fully autonomous AI assistant infrastructure</summary>
+
+- **Source**: source
+- **License**: MIT
+- **Homepage**: https://github.com/zeroclaw-labs/zeroclaw
+- **Usage**: `nix run github:numtide/llm-agents.nix#zeroclaw -- --help`
+- **Nix**: [packages/zeroclaw/package.nix](packages/zeroclaw/package.nix)
+
+</details>
+
 ### Claude Code Ecosystem
 
 <details>
@@ -579,16 +622,6 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
-<summary><strong>localgpt</strong> - Local AI assistant with persistent markdown memory, autonomous tasks, and semantic search</summary>
-
-- **Source**: source
-- **License**: Apache-2.0
-- **Homepage**: https://github.com/localgpt-app/localgpt
-- **Usage**: `nix run github:numtide/llm-agents.nix#localgpt -- --help`
-- **Nix**: [packages/localgpt/package.nix](packages/localgpt/package.nix)
-
-</details>
-<details>
 <summary><strong>mcporter</strong> - TypeScript runtime and CLI for the Model Context Protocol</summary>
 
 - **Source**: source
@@ -596,16 +629,6 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 - **Homepage**: https://github.com/steipete/mcporter
 - **Usage**: `nix run github:numtide/llm-agents.nix#mcporter -- --help`
 - **Nix**: [packages/mcporter/package.nix](packages/mcporter/package.nix)
-
-</details>
-<details>
-<summary><strong>openclaw</strong> - Your own personal AI assistant. Any OS. Any Platform. The lobster way</summary>
-
-- **Source**: source
-- **License**: MIT
-- **Homepage**: https://openclaw.ai
-- **Usage**: `nix run github:numtide/llm-agents.nix#openclaw -- --help`
-- **Nix**: [packages/openclaw/package.nix](packages/openclaw/package.nix)
 
 </details>
 <details>

--- a/packages/localgpt/package.nix
+++ b/packages/localgpt/package.nix
@@ -86,7 +86,7 @@ rustPlatform.buildRustPackage {
     versionCheckHomeHook
   ];
 
-  passthru.category = "Utilities";
+  passthru.category = "AI Assistants";
 
   meta = with lib; {
     description = "Local AI assistant with persistent markdown memory, autonomous tasks, and semantic search";

--- a/packages/openclaw/package.nix
+++ b/packages/openclaw/package.nix
@@ -105,7 +105,7 @@ stdenv.mkDerivation (finalAttrs: {
     versionCheckHomeHook
   ];
 
-  passthru.category = "Utilities";
+  passthru.category = "AI Assistants";
 
   meta = {
     description = "Your own personal AI assistant. Any OS. Any Platform. The lobster way";

--- a/packages/picoclaw/package.nix
+++ b/packages/picoclaw/package.nix
@@ -46,7 +46,7 @@ buildGoModule.override { go = go_1_25; } rec {
     versionCheckHomeHook
   ];
 
-  passthru.category = "AI Coding Agents";
+  passthru.category = "AI Assistants";
 
   meta = {
     description = "Tiny, fast, and deployable anywhere — automate the mundane, unleash your creativity";

--- a/packages/zeroclaw/package.nix
+++ b/packages/zeroclaw/package.nix
@@ -29,7 +29,7 @@ rustPlatform.buildRustPackage rec {
     versionCheckHomeHook
   ];
 
-  passthru.category = "AI Coding Agents";
+  passthru.category = "AI Assistants";
 
   meta = {
     description = "Fast, small, and fully autonomous AI assistant infrastructure";

--- a/scripts/generate-package-docs.py
+++ b/scripts/generate-package-docs.py
@@ -76,6 +76,7 @@ def generate_package_doc(package: str, metadata: dict[str, str | bool | None]) -
 # Define category order for display
 CATEGORY_ORDER = [
     "AI Coding Agents",
+    "AI Assistants",
     "Claude Code Ecosystem",
     "ACP Ecosystem",
     "MCP",


### PR DESCRIPTION
Not all packaged tools are coding agents — localgpt, openclaw, zeroclaw, and picoclaw are general-purpose AI assistants. Group them under a dedicated "AI Assistants" category so users can more easily find the right tool for their use case.