### PR TITLE
crush: 0.43.2 -> 0.43.4

### DIFF
--- a/packages/crush/hashes.json
+++ b/packages/crush/hashes.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.43.2",
-  "hash": "sha256-VyV57ASsn2t1zaW7L6o7sVc+H+tHf4AP1HaKgrdXrtk=",
-  "vendorHash": "sha256-qFqFyPdAqh2BXeE2tkLmn88Z8qHFeSlTA2Ols8H7iaQ="
+  "version": "0.43.4",
+  "hash": "sha256-ShvLnI5VXq3yq/PL462dvlzCl7oqut1qnxmbQPdRoWQ=",
+  "vendorHash": "sha256-f0cQEZrwo1diUdA4B8Xjm66Ws5l/nMLJoPP6Azsibvk="
 }

--- a/packages/crush/package.nix
+++ b/packages/crush/package.nix
@@ -3,7 +3,7 @@
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
-  go_1_25,
+  go_1_26,
   versionCheckHook,
   versionCheckHomeHook,
 }:
@@ -11,6 +11,10 @@
 let
   versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
   inherit (versionData) version hash vendorHash;
+in
+(buildGoModule.override { go = go_1_26; }) {
+  pname = "crush";
+  inherit version vendorHash;
 
   src = fetchFromGitHub {
     owner = "charmbracelet";
@@ -18,26 +22,6 @@ let
     rev = "v${version}";
     inherit hash;
   };
-
-  # Override Go to report the required version to satisfy all dependency version requirements
-  # This is simpler than patching all transitive dependencies
-  # The actual Go 1.25.4 toolchain is API-compatible with 1.25.5+ requirements
-  go_1_25_patched = go_1_25.overrideAttrs (oldAttrs: {
-    # Patch the version file that Go reads to determine its version
-    # Extract the required version from crush's go.mod to make it future-compatible
-    postPatch = (oldAttrs.postPatch or "") + ''
-      # Extract the required Go version from crush's go.mod
-      REQUIRED_VERSION=$(grep -E "^go [0-9]+\.[0-9]+(\.[0-9]+)?" ${src}/go.mod | \
-        sed -E 's/^go ([0-9]+\.[0-9]+(\.[0-9]+)?)/\1/')
-
-      # Update VERSION file to report the required Go version
-      echo "go$REQUIRED_VERSION" > VERSION
-    '';
-  });
-in
-(buildGoModule.override { go = go_1_25_patched; }) {
-  pname = "crush";
-  inherit version vendorHash src;
 
   nativeBuildInputs = [ installShellFiles ];
 


### PR DESCRIPTION
go_1_26 is now available in nixpkgs (NixOS/nixpkgs#490463), so switch to it directly instead of the previous go_1_25 workaround that patched the Go binary to report a newer version.

## Summary

<!-- Briefly describe what this PR does -->

## Test plan

<!-- How did you test this change? -->

- [ ] `nix build .#<package>` succeeds
- [ ] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
