### PR TITLE
claude-code: allow overriding DISABLE_TELEMETRY variables

### DIFF
--- a/packages/claude-code/package.nix
+++ b/packages/claude-code/package.nix
@@ -56,9 +56,9 @@ stdenv.mkDerivation {
     wrapProgram $out/bin/claude \
       --argv0 claude \
       --set DISABLE_AUTOUPDATER 1 \
-      --set CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC 1 \
-      --set DISABLE_NON_ESSENTIAL_MODEL_CALLS 1 \
-      --set DISABLE_TELEMETRY 1 \
+      --set-default CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC 1 \
+      --set-default DISABLE_NON_ESSENTIAL_MODEL_CALLS 1 \
+      --set-default DISABLE_TELEMETRY 1 \
       --set DISABLE_INSTALLATION_CHECKS 1 ${lib.optionalString stdenv.hostPlatform.isLinux "--prefix PATH : ${
         lib.makeBinPath [
           bubblewrap


### PR DESCRIPTION
## Summary

Make `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC`, `DISABLE_NON_ESSENTIAL_MODEL_CALLS`, and `DISABLE_TELEMETRY` overridable by environment variables.

Fixed #2811

## Test plan

<!-- How did you test this change? -->

- [x] `nix build .#<package>` succeeds
- [x] ~~Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work~~
- [x] Make sure `remote-control` can be enabled by erasing the telemetry variables
- [x] Dogfooding

```
❯ ./result/bin/claude remote-control
Error: Remote Control is not yet available on your plan.
❯ CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC= DISABLE_TELEMETRY= ./result/bin/claude remote-control

Remote Control lets you access this CLI session from the web (claude.ai/code)
or the Claude app, so you can pick up where you left off on any device.

You can disconnect remote access anytime by running /remote-control again.

Enable Remote Control? (y/n) %
```
