### PR TITLE
rtk: improve package with finalAttrs, version checks, and faster builds

### DIFF
--- a/packages/rtk/default.nix
+++ b/packages/rtk/default.nix
@@ -1,1 +1,4 @@
-{ pkgs }: pkgs.callPackage ./package.nix { }
+{ pkgs, perSystem, ... }:
+pkgs.callPackage ./package.nix {
+  inherit (perSystem.self) versionCheckHomeHook;
+}


### PR DESCRIPTION
## Summary

- Switch from `rec` to `finalAttrs` pattern
- Use `tag` instead of deprecated `rev` in `fetchFromGitHub`
- Add `versionCheckHook` and `versionCheckHomeHook` for install checks
- Disable LTO and single codegen-unit in `postPatch` for faster Nix builds
- Update maintainer to ryoppippi

## Test plan

- [x] `nix build .#rtk` succeeds
- [x] `rtk --version` outputs `rtk 0.22.2`
- [x] `rtk-rewrite.sh` hook is installed at `$out/libexec/rtk/hooks/`
- [x] `nix fmt` passes with no changes