### PR TITLE
cc-switch-cli: init at 4.7.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>cc-switch-cli</strong> - CLI version of CC Switch - All-in-One Assistant for Claude Code, Codex & Gemini CLI</summary>
+
+- **Source**: binary
+- **License**: MIT
+- **Homepage**: https://github.com/SaladDay/cc-switch-cli
+- **Usage**: `nix run github:numtide/llm-agents.nix#cc-switch-cli -- --help`
+- **Nix**: [packages/cc-switch-cli/package.nix](packages/cc-switch-cli/package.nix)
+
+</details>
+<details>
 <summary><strong>ccstatusline</strong> - A highly customizable status line formatter for Claude Code CLI</summary>
 
 - **Source**: bytecode
@@ -609,6 +619,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 - **Homepage**: https://github.com/github/copilot-language-server-release
 - **Usage**: `nix run github:numtide/llm-agents.nix#copilot-language-server -- --help`
 - **Nix**: [packages/copilot-language-server/package.nix](packages/copilot-language-server/package.nix)
+
+</details>
+<details>
+<summary><strong>entire</strong> - CLI tool that captures AI agent sessions and links them to code changes</summary>
+
+- **Source**: source
+- **License**: MIT
+- **Homepage**: https://github.com/entireio/cli
+- **Usage**: `nix run github:numtide/llm-agents.nix#entire -- --help`
+- **Nix**: [packages/entire/package.nix](packages/entire/package.nix)
 
 </details>
 <details>

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -52,6 +52,11 @@ inputs.nixpkgs.lib.extend (
         githubId = 91340399;
         name = "Yuta Kobayashi";
       };
+      zrubing = {
+        github = "zrubing";
+        githubId = 21324081;
+        name = "Rubing";
+      };
     };
   }
 )

--- a/packages/cc-switch-cli/default.nix
+++ b/packages/cc-switch-cli/default.nix
@@ -1,0 +1,10 @@
+{
+  pkgs,
+  flake,
+  perSystem,
+  ...
+}:
+pkgs.callPackage ./package.nix {
+  inherit flake;
+  inherit (perSystem.self) versionCheckHomeHook;
+}

--- a/packages/cc-switch-cli/package.nix
+++ b/packages/cc-switch-cli/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  flake,
+  fetchFromGitHub,
+  rustPlatform,
+  versionCheckHook,
+  versionCheckHomeHook,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "cc-switch-cli";
+  version = "4.7.3";
+
+  src = fetchFromGitHub {
+    owner = "SaladDay";
+    repo = "cc-switch-cli";
+    tag = "v${version}";
+    hash = "sha256-mu3vQtQIuDE5QSSsbfkOLhv6Z56etBcsxO6PjyzYVRI=";
+  };
+
+  cargoRoot = "src-tauri";
+  buildAndTestSubdir = "src-tauri";
+
+  cargoHash = "sha256-S4h5qn7MwGFe8FvagTyzX/pW4I/PZVU9kuiqDVo3K0I=";
+
+  # Tests require network access and runtime configuration
+  doCheck = false;
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    versionCheckHomeHook
+  ];
+
+  passthru.category = "Claude Code Ecosystem";
+
+  meta = with lib; {
+    description = "CLI version of CC Switch - All-in-One Assistant for Claude Code, Codex & Gemini CLI";
+    homepage = "https://github.com/SaladDay/cc-switch-cli";
+    changelog = "https://github.com/SaladDay/cc-switch-cli/releases/tag/v${version}";
+    downloadPage = "https://github.com/SaladDay/cc-switch-cli/releases";
+    license = licenses.mit;
+    sourceProvenance = with sourceTypes; [ fromSource ];
+    maintainers = with flake.lib.maintainers; [ zrubing ];
+    mainProgram = "cc-switch";
+    platforms = platforms.unix;
+  };
+}


### PR DESCRIPTION
Build from source using rustPlatform.buildRustPackage. Cargo workspace lives in src-tauri/ subdirectory.

## Summary

<!-- Briefly describe what this PR does -->

## Test plan

<!-- How did you test this change? -->

- [ ] `nix build .#<package>` succeeds
- [ ] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
