### PR TITLE
beads: 0.56.1 -> 0.57.0

### DIFF
--- a/packages/beads/package.nix
+++ b/packages/beads/package.nix
@@ -8,16 +8,16 @@
 
 buildGoModule rec {
   pname = "beads";
-  version = "0.56.1";
+  version = "0.57.0";
 
   src = fetchFromGitHub {
     owner = "steveyegge";
     repo = "beads";
     rev = "v${version}";
-    hash = "sha256-hp+mKVCSzxxxUtOqspXuTbOJpeC8K9+UmmXSDr5Xa0k=";
+    hash = "sha256-BjDuqadUtNMeiclWzRNnx/lXjUvHkj+F7J17VfCMEH0=";
   };
 
-  vendorHash = "sha256-DlEnIVNLHWetwQxTmUNOAuDbHGZ9mmLdITwDdviphPs=";
+  vendorHash = "sha256-uf6ET13OImaGk22I9MJ/wJvX8F0bXaEkf726De/80PY=";
 
   nativeBuildInputs = [ unpinGoModVersionHook ];
 


### PR DESCRIPTION
## Summary

- Update beads (bd) from 0.56.1 to 0.57.0
- Updated via `nix-update`, build verified

### Notable changes in v0.57.0

- **Dolt integration improvements**: SSH push/pull fallback, dual-surface remote management, auto-push with 5-minute debounce, `bd dolt remote` subcommands
- **Backup**: JSONL backup command, auto-backup support, `bd backup restore` for bootstrapping from backup
- **New features**: `dolt-data-dir` config, `--database` flag for `bd init`, per-worktree `.beads/redirect`, `has_metadata_key` in query DSL, MCP claim tool, label inheritance

Full changelog: https://github.com/steveyegge/beads/releases/tag/v0.57.0