### PR TITLE
qmd: fix EROFS crash when CUDA prebuilt binary fails compatibility test

### DIFF
--- a/packages/qmd/node-llama-cpp-nix-compat.patch
+++ b/packages/qmd/node-llama-cpp-nix-compat.patch
@@ -1,0 +1,11 @@
+--- a/node_modules/node-llama-cpp/dist/config.js
++++ b/node_modules/node-llama-cpp/dist/config.js
+@@ -11,7 +11,7 @@
+ export const llamaDirectory = path.join(__dirname, "..", "llama");
+ export const llamaToolchainsDirectory = path.join(llamaDirectory, "toolchains");
+ export const llamaPrebuiltBinsDirectory = path.join(__dirname, "..", "bins");
+-export const llamaLocalBuildBinsDirectory = path.join(llamaDirectory, "localBuilds");
++export const llamaLocalBuildBinsDirectory = path.join(os.homedir(), ".cache", "node-llama-cpp", "localBuilds");
+ export const llamaBinsGrammarsDirectory = path.join(__dirname, "..", "llama", "grammars");
+ export const projectTemplatesDirectory = path.join(__dirname, "..", "templates");
+ export const packedProjectTemplatesDirectory = path.join(projectTemplatesDirectory, "packed");

--- a/packages/qmd/package.nix
+++ b/packages/qmd/package.nix
@@ -115,6 +115,13 @@ stdenv.mkDerivation {
       # Without this patch, it falls back to building llama.cpp which fails in read-only store
       patch -p1 -d $out/lib/qmd < ${./node-llama-cpp-detectGlibc.patch}
 
+      # Redirect localBuilds directory from the read-only Nix store to a writable
+      # user cache path. When the prebuilt CUDA binary fails its compatibility test,
+      # node-llama-cpp falls back to building from source and tries to create a
+      # lockfile + output directory inside its own package dir. On NixOS this is
+      # /nix/store/... which is read-only, causing EROFS errors.
+      patch -p1 -d $out/lib/qmd < ${./node-llama-cpp-nix-compat.patch}
+
       makeWrapper ${bun}/bin/bun $out/bin/qmd \
         --add-flags "$out/lib/qmd/src/qmd.ts" \
         --set DYLD_LIBRARY_PATH "${sqlite.out}/lib" \


### PR DESCRIPTION
## Problem

When CUDA is available but the prebuilt CUDA binary fails its runtime compatibility test, `node-llama-cpp` falls back to building `llama.cpp` from source. It tries to create a lockfile and output directory inside its own package directory, which on NixOS is the read-only `/nix/store/`. This causes an `EROFS: read-only file system` error:

```
[node-llama-cpp] Failed to acquire lockfile for "/nix/store/.../node_modules/node-llama-cpp/llama/localBuilds/linux-x64-cuda"
EROFS: read-only file system, mkdir '/nix/store/.../localBuilds/linux-x64-cuda.lock'
```

## Root Cause

`node-llama-cpp` sets `llamaLocalBuildBinsDirectory` relative to its own `__dirname` (inside the package). On NixOS, this resolves to a path inside the immutable Nix store.

## Fix

Redirect `llamaLocalBuildBinsDirectory` to `~/.cache/node-llama-cpp/localBuilds`, a writable user cache directory. This prevents the EROFS crash when the build-from-source fallback is triggered.

Fixes #2957