### PR TITLE
Revert "pi: 0.55.4 -> 0.56.0"

### DIFF
--- a/packages/pi/hashes.json
+++ b/packages/pi/hashes.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.56.0",
-  "sourceHash": "sha256-IKsgoPEaeoGaYMM1ghR3UPdshCLsLVulLwTmP0cbdXI=",
-  "npmDepsHash": "sha256-zX8lIMDzf2kukTrsG2ypFyQiLZvgSEDnsi2ejSHcmk0="
+  "version": "0.55.4",
+  "sourceHash": "sha256-GnzPe1QJcFhpLZVlREvgRu/zh3GTXxeK/o58DdQ6QiI=",
+  "npmDepsHash": "sha256-ORxyljMETx0AN1fQ1H28u0/8CxlGF6vXZ1iszXXMU2A="
 }

--- a/packages/pi/package-lock.json
+++ b/packages/pi/package-lock.json
@@ -1,18 +1,18 @@
 {
 	"name": "@mariozechner/pi-coding-agent",
-	"version": "0.56.0",
+	"version": "0.55.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@mariozechner/pi-coding-agent",
-			"version": "0.56.0",
+			"version": "0.55.4",
 			"license": "MIT",
 			"dependencies": {
 				"@mariozechner/jiti": "^2.6.2",
-				"@mariozechner/pi-agent-core": "^0.56.0",
-				"@mariozechner/pi-ai": "^0.56.0",
-				"@mariozechner/pi-tui": "^0.56.0",
+				"@mariozechner/pi-agent-core": "^0.55.4",
+				"@mariozechner/pi-ai": "^0.55.4",
+				"@mariozechner/pi-tui": "^0.55.4",
 				"@silvia-odwyer/photon-node": "^0.3.4",
 				"chalk": "^5.5.0",
 				"cli-highlight": "^2.1.11",
@@ -25,8 +25,6 @@
 				"marked": "^15.0.12",
 				"minimatch": "^10.2.3",
 				"proper-lockfile": "^4.1.2",
-				"strip-ansi": "^7.1.0",
-				"undici": "^7.19.1",
 				"yaml": "^2.8.2"
 			},
 			"bin": {
@@ -209,56 +207,56 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-bedrock-runtime": {
-			"version": "3.1002.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1002.0.tgz",
-			"integrity": "sha512-xUmzgTvTeQFVxBqla8U4nXpZNXLcZ0xszfZ4yxdTUNyChQQb7JLaH4E8pAbl7ulg0RoJ4ChNWtOqMJC/N3+qcQ==",
+			"version": "3.1000.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1000.0.tgz",
+			"integrity": "sha512-GA96wgTFB4Z5vhysm+hErbgiEWZ9JqAl09BxARajL7Oanpf0KvdIjxuLp2rD/XqEIks9yG/5Rh9XIAoCUUTZXw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "^3.973.17",
-				"@aws-sdk/credential-provider-node": "^3.972.16",
+				"@aws-sdk/core": "^3.973.15",
+				"@aws-sdk/credential-provider-node": "^3.972.14",
 				"@aws-sdk/eventstream-handler-node": "^3.972.9",
 				"@aws-sdk/middleware-eventstream": "^3.972.6",
 				"@aws-sdk/middleware-host-header": "^3.972.6",
 				"@aws-sdk/middleware-logger": "^3.972.6",
 				"@aws-sdk/middleware-recursion-detection": "^3.972.6",
-				"@aws-sdk/middleware-user-agent": "^3.972.17",
-				"@aws-sdk/middleware-websocket": "^3.972.11",
+				"@aws-sdk/middleware-user-agent": "^3.972.15",
+				"@aws-sdk/middleware-websocket": "^3.972.10",
 				"@aws-sdk/region-config-resolver": "^3.972.6",
-				"@aws-sdk/token-providers": "3.1002.0",
+				"@aws-sdk/token-providers": "3.1000.0",
 				"@aws-sdk/types": "^3.973.4",
 				"@aws-sdk/util-endpoints": "^3.996.3",
 				"@aws-sdk/util-user-agent-browser": "^3.972.6",
-				"@aws-sdk/util-user-agent-node": "^3.973.2",
+				"@aws-sdk/util-user-agent-node": "^3.973.0",
 				"@smithy/config-resolver": "^4.4.9",
-				"@smithy/core": "^3.23.7",
+				"@smithy/core": "^3.23.6",
 				"@smithy/eventstream-serde-browser": "^4.2.10",
 				"@smithy/eventstream-serde-config-resolver": "^4.3.10",
 				"@smithy/eventstream-serde-node": "^4.2.10",
-				"@smithy/fetch-http-handler": "^5.3.12",
+				"@smithy/fetch-http-handler": "^5.3.11",
 				"@smithy/hash-node": "^4.2.10",
 				"@smithy/invalid-dependency": "^4.2.10",
 				"@smithy/middleware-content-length": "^4.2.10",
-				"@smithy/middleware-endpoint": "^4.4.21",
-				"@smithy/middleware-retry": "^4.4.38",
+				"@smithy/middleware-endpoint": "^4.4.20",
+				"@smithy/middleware-retry": "^4.4.37",
 				"@smithy/middleware-serde": "^4.2.11",
 				"@smithy/middleware-stack": "^4.2.10",
 				"@smithy/node-config-provider": "^4.3.10",
-				"@smithy/node-http-handler": "^4.4.13",
+				"@smithy/node-http-handler": "^4.4.12",
 				"@smithy/protocol-http": "^5.3.10",
-				"@smithy/smithy-client": "^4.12.1",
+				"@smithy/smithy-client": "^4.12.0",
 				"@smithy/types": "^4.13.0",
 				"@smithy/url-parser": "^4.2.10",
 				"@smithy/util-base64": "^4.3.1",
 				"@smithy/util-body-length-browser": "^4.2.1",
 				"@smithy/util-body-length-node": "^4.2.2",
-				"@smithy/util-defaults-mode-browser": "^4.3.37",
-				"@smithy/util-defaults-mode-node": "^4.2.40",
+				"@smithy/util-defaults-mode-browser": "^4.3.36",
+				"@smithy/util-defaults-mode-node": "^4.2.39",
 				"@smithy/util-endpoints": "^3.3.1",
 				"@smithy/util-middleware": "^4.2.10",
 				"@smithy/util-retry": "^4.2.10",
-				"@smithy/util-stream": "^4.5.16",
+				"@smithy/util-stream": "^4.5.15",
 				"@smithy/util-utf8": "^4.2.1",
 				"tslib": "^2.6.2"
 			},
@@ -267,19 +265,19 @@
 			}
 		},
 		"node_modules/@aws-sdk/core": {
-			"version": "3.973.17",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.17.tgz",
-			"integrity": "sha512-VtgGP0TjbCeyp6DQpiBqJKbemTSIaN2bZc3UbeTDCani3lBCyxn75ouJYD6koSSp0bh7rKLEbUpiFsNCI7tr0w==",
+			"version": "3.973.15",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.15.tgz",
+			"integrity": "sha512-AlC0oQ1/mdJ8vCIqu524j5RB7M8i8E24bbkZmya1CuiQxkY7SdIZAyw7NDNMGaNINQFq/8oGRMX0HeOfCVsl/A==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/types": "^3.973.4",
-				"@aws-sdk/xml-builder": "^3.972.9",
-				"@smithy/core": "^3.23.7",
+				"@aws-sdk/xml-builder": "^3.972.8",
+				"@smithy/core": "^3.23.6",
 				"@smithy/node-config-provider": "^4.3.10",
 				"@smithy/property-provider": "^4.2.10",
 				"@smithy/protocol-http": "^5.3.10",
 				"@smithy/signature-v4": "^5.3.10",
-				"@smithy/smithy-client": "^4.12.1",
+				"@smithy/smithy-client": "^4.12.0",
 				"@smithy/types": "^4.13.0",
 				"@smithy/util-base64": "^4.3.1",
 				"@smithy/util-middleware": "^4.2.10",
@@ -291,12 +289,12 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-env": {
-			"version": "3.972.15",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.15.tgz",
-			"integrity": "sha512-RhHQG1lhkWHL4tK1C/KDjaOeis+9U0tAMnWDiwiSVQZMC7CsST9Xin+sK89XywJ5g/tyABtb7TvFePJ4Te5XSQ==",
+			"version": "3.972.13",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.13.tgz",
+			"integrity": "sha512-6ljXKIQ22WFKyIs1jbORIkGanySBHaPPTOI4OxACP5WXgbcR0nDYfqNJfXEGwCK7IzHdNbCSFsNKKs0qCexR8Q==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.973.17",
+				"@aws-sdk/core": "^3.973.15",
 				"@aws-sdk/types": "^3.973.4",
 				"@smithy/property-provider": "^4.2.10",
 				"@smithy/types": "^4.13.0",
@@ -307,20 +305,20 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-http": {
-			"version": "3.972.17",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.17.tgz",
-			"integrity": "sha512-b/bDL76p51+yQ+0O9ZDH5nw/ioE0sRYkjwjOwFWAWZXo6it2kQZUOXhVpjohx3ldKyUxt/SwAivjUu1Nr/PWlQ==",
+			"version": "3.972.15",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.15.tgz",
+			"integrity": "sha512-dJuSTreu/T8f24SHDNTjd7eQ4rabr0TzPh2UTCwYexQtzG3nTDKm1e5eIdhiroTMDkPEJeY+WPkA6F9wod/20A==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.973.17",
+				"@aws-sdk/core": "^3.973.15",
 				"@aws-sdk/types": "^3.973.4",
-				"@smithy/fetch-http-handler": "^5.3.12",
-				"@smithy/node-http-handler": "^4.4.13",
+				"@smithy/fetch-http-handler": "^5.3.11",
+				"@smithy/node-http-handler": "^4.4.12",
 				"@smithy/property-provider": "^4.2.10",
 				"@smithy/protocol-http": "^5.3.10",
-				"@smithy/smithy-client": "^4.12.1",
+				"@smithy/smithy-client": "^4.12.0",
 				"@smithy/types": "^4.13.0",
-				"@smithy/util-stream": "^4.5.16",
+				"@smithy/util-stream": "^4.5.15",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -328,19 +326,19 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-ini": {
-			"version": "3.972.15",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.15.tgz",
-			"integrity": "sha512-qWnM+wB8MmU2kKY7f4KowKjOjkwRosaFxrtseEEIefwoXn1SjN+CbHzXBVdTAQxxkbBiqhPgJ/WHiPtES4grRQ==",
+			"version": "3.972.13",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.13.tgz",
+			"integrity": "sha512-JKSoGb7XeabZLBJptpqoZIFbROUIS65NuQnEHGOpuT9GuuZwag2qciKANiDLFiYk4u8nSrJC9JIOnWKVvPVjeA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.973.17",
-				"@aws-sdk/credential-provider-env": "^3.972.15",
-				"@aws-sdk/credential-provider-http": "^3.972.17",
-				"@aws-sdk/credential-provider-login": "^3.972.15",
-				"@aws-sdk/credential-provider-process": "^3.972.15",
-				"@aws-sdk/credential-provider-sso": "^3.972.15",
-				"@aws-sdk/credential-provider-web-identity": "^3.972.15",
-				"@aws-sdk/nested-clients": "^3.996.5",
+				"@aws-sdk/core": "^3.973.15",
+				"@aws-sdk/credential-provider-env": "^3.972.13",
+				"@aws-sdk/credential-provider-http": "^3.972.15",
+				"@aws-sdk/credential-provider-login": "^3.972.13",
+				"@aws-sdk/credential-provider-process": "^3.972.13",
+				"@aws-sdk/credential-provider-sso": "^3.972.13",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.13",
+				"@aws-sdk/nested-clients": "^3.996.3",
 				"@aws-sdk/types": "^3.973.4",
 				"@smithy/credential-provider-imds": "^4.2.10",
 				"@smithy/property-provider": "^4.2.10",
@@ -353,13 +351,13 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-login": {
-			"version": "3.972.15",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.15.tgz",
-			"integrity": "sha512-x92FJy34/95wgu+qOGD8SHcgh1hZ9Qx2uFtQEGn4m9Ljou8ICIv3Ybq5yxdB7A60S8ZGCQB0mIopmjJwiLbh5g==",
+			"version": "3.972.13",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.13.tgz",
+			"integrity": "sha512-RtYcrxdnJHKY8MFQGLltCURcjuMjnaQpAxPE6+/QEdDHHItMKZgabRe/KScX737F9vJMQsmJy9EmMOkCnoC1JQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.973.17",
-				"@aws-sdk/nested-clients": "^3.996.5",
+				"@aws-sdk/core": "^3.973.15",
+				"@aws-sdk/nested-clients": "^3.996.3",
 				"@aws-sdk/types": "^3.973.4",
 				"@smithy/property-provider": "^4.2.10",
 				"@smithy/protocol-http": "^5.3.10",
@@ -372,17 +370,17 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-node": {
-			"version": "3.972.16",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.16.tgz",
-			"integrity": "sha512-7mlt14Ee4rPFAFUVgpWE7+0CBhetJJyzVFqfIsMp7sgyOSm9Y/+qHZOWAuK5I4JNc+Y5PltvJ9kssTzRo92iXQ==",
+			"version": "3.972.14",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.14.tgz",
+			"integrity": "sha512-WqoC2aliIjQM/L3oFf6j+op/enT2i9Cc4UTxxMEKrJNECkq4/PlKE5BOjSYFcq6G9mz65EFbXJh7zOU4CvjSKQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/credential-provider-env": "^3.972.15",
-				"@aws-sdk/credential-provider-http": "^3.972.17",
-				"@aws-sdk/credential-provider-ini": "^3.972.15",
-				"@aws-sdk/credential-provider-process": "^3.972.15",
-				"@aws-sdk/credential-provider-sso": "^3.972.15",
-				"@aws-sdk/credential-provider-web-identity": "^3.972.15",
+				"@aws-sdk/credential-provider-env": "^3.972.13",
+				"@aws-sdk/credential-provider-http": "^3.972.15",
+				"@aws-sdk/credential-provider-ini": "^3.972.13",
+				"@aws-sdk/credential-provider-process": "^3.972.13",
+				"@aws-sdk/credential-provider-sso": "^3.972.13",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.13",
 				"@aws-sdk/types": "^3.973.4",
 				"@smithy/credential-provider-imds": "^4.2.10",
 				"@smithy/property-provider": "^4.2.10",
@@ -395,12 +393,12 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-process": {
-			"version": "3.972.15",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.15.tgz",
-			"integrity": "sha512-PrH3iTeD18y/8uJvQD2s/T87BTGhsdS/1KZU7ReWHXsplBwvCqi7AbnnNbML1pFlQwRWCE2RdSZFWDVId3CvkA==",
+			"version": "3.972.13",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.13.tgz",
+			"integrity": "sha512-rsRG0LQA4VR+jnDyuqtXi2CePYSmfm5GNL9KxiW8DSe25YwJSr06W8TdUfONAC+rjsTI+aIH2rBGG5FjMeANrw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.973.17",
+				"@aws-sdk/core": "^3.973.15",
 				"@aws-sdk/types": "^3.973.4",
 				"@smithy/property-provider": "^4.2.10",
 				"@smithy/shared-ini-file-loader": "^4.4.5",
@@ -412,14 +410,32 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-sso": {
-			"version": "3.972.15",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.15.tgz",
-			"integrity": "sha512-M/+LBHTPKZxxXckM6m4dnJeR+jlm9NynH9b2YDswN4Zj2St05SK/crdL3Wy3WfJTZootnnhm3oTh87Usl7PS7w==",
+			"version": "3.972.13",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.13.tgz",
+			"integrity": "sha512-fr0UU1wx8kNHDhTQBXioc/YviSW8iXuAxHvnH7eQUtn8F8o/FU3uu6EUMvAQgyvn7Ne5QFnC0Cj0BFlwCk+RFw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.973.17",
-				"@aws-sdk/nested-clients": "^3.996.5",
-				"@aws-sdk/token-providers": "3.1002.0",
+				"@aws-sdk/core": "^3.973.15",
+				"@aws-sdk/nested-clients": "^3.996.3",
+				"@aws-sdk/token-providers": "3.999.0",
+				"@aws-sdk/types": "^3.973.4",
+				"@smithy/property-provider": "^4.2.10",
+				"@smithy/shared-ini-file-loader": "^4.4.5",
+				"@smithy/types": "^4.13.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
+			"version": "3.999.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.999.0.tgz",
+			"integrity": "sha512-cx0hHUlgXULfykx4rdu/ciNAJaa3AL5xz3rieCz7NKJ68MJwlj3664Y8WR5MGgxfyYJBdamnkjNSx5Kekuc0cg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.973.15",
+				"@aws-sdk/nested-clients": "^3.996.3",
 				"@aws-sdk/types": "^3.973.4",
 				"@smithy/property-provider": "^4.2.10",
 				"@smithy/shared-ini-file-loader": "^4.4.5",
@@ -431,13 +447,13 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-web-identity": {
-			"version": "3.972.15",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.15.tgz",
-			"integrity": "sha512-QTH6k93v+UOfFam/ado8zc71tH+enTVyuvLy9uEWXX1x894dN5ovtf/MdBDgFwq3g6c9mbtgVJ4B+yBqDtXvdA==",
+			"version": "3.972.13",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.13.tgz",
+			"integrity": "sha512-a6iFMh1pgUH0TdcouBppLJUfPM7Yd3R9S1xFodPtCRoLqCz2RQFA3qjA8x4112PVYXEd4/pHX2eihapq39w0rA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.973.17",
-				"@aws-sdk/nested-clients": "^3.996.5",
+				"@aws-sdk/core": "^3.973.15",
+				"@aws-sdk/nested-clients": "^3.996.3",
 				"@aws-sdk/types": "^3.973.4",
 				"@smithy/property-provider": "^4.2.10",
 				"@smithy/shared-ini-file-loader": "^4.4.5",
@@ -524,15 +540,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-user-agent": {
-			"version": "3.972.17",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.17.tgz",
-			"integrity": "sha512-HHArkgWzomuwufXwheQqkddu763PWCpoNTq1dGjqXzJT/lojX3VlOqjNSR2Xvb6/T9ISfwYcMOcbFgUp4EWxXA==",
+			"version": "3.972.15",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.15.tgz",
+			"integrity": "sha512-ABlFVcIMmuRAwBT+8q5abAxOr7WmaINirDJBnqGY5b5jSDo00UMlg/G4a0xoAgwm6oAECeJcwkvDlxDwKf58fQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.973.17",
+				"@aws-sdk/core": "^3.973.15",
 				"@aws-sdk/types": "^3.973.4",
 				"@aws-sdk/util-endpoints": "^3.996.3",
-				"@smithy/core": "^3.23.7",
+				"@smithy/core": "^3.23.6",
 				"@smithy/protocol-http": "^5.3.10",
 				"@smithy/types": "^4.13.0",
 				"tslib": "^2.6.2"
@@ -542,16 +558,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-websocket": {
-			"version": "3.972.11",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.11.tgz",
-			"integrity": "sha512-cWf+8iUUnitgFuUu/ryK2uVfx7f5ezdhGwsjLLEEC1Nk716Ld2Hw4LA8iipyVcQI3EarvK6ExY2dSBET/0PYng==",
+			"version": "3.972.10",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.10.tgz",
+			"integrity": "sha512-uNqRpbL6djE+XXO4cQ+P8ra37cxNNBP+2IfkVOXu1xFdGMfW+uOTxBQuDPpP43i40PBRBXK5un79l/oYpbzYkA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/types": "^3.973.4",
 				"@aws-sdk/util-format-url": "^3.972.6",
 				"@smithy/eventstream-codec": "^4.2.10",
 				"@smithy/eventstream-serde-browser": "^4.2.10",
-				"@smithy/fetch-http-handler": "^5.3.12",
+				"@smithy/fetch-http-handler": "^5.3.11",
 				"@smithy/protocol-http": "^5.3.10",
 				"@smithy/signature-v4": "^5.3.10",
 				"@smithy/types": "^4.13.0",
@@ -565,44 +581,44 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients": {
-			"version": "3.996.5",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.5.tgz",
-			"integrity": "sha512-zn0WApcULn7Rtl6T+KP2CQTZo/7wOa2YV1yHQnbijTQoi4YXQHM8s21JcJzt33/mqPh8AdvWX1f+83KvKuxlZw==",
+			"version": "3.996.3",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.3.tgz",
+			"integrity": "sha512-AU5TY1V29xqwg/MxmA2odwysTez+ccFAhmfRJk+QZT5HNv90UTA9qKd1J9THlsQkvmH7HWTEV1lDNxkQO5PzNw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "^3.973.17",
+				"@aws-sdk/core": "^3.973.15",
 				"@aws-sdk/middleware-host-header": "^3.972.6",
 				"@aws-sdk/middleware-logger": "^3.972.6",
 				"@aws-sdk/middleware-recursion-detection": "^3.972.6",
-				"@aws-sdk/middleware-user-agent": "^3.972.17",
+				"@aws-sdk/middleware-user-agent": "^3.972.15",
 				"@aws-sdk/region-config-resolver": "^3.972.6",
 				"@aws-sdk/types": "^3.973.4",
 				"@aws-sdk/util-endpoints": "^3.996.3",
 				"@aws-sdk/util-user-agent-browser": "^3.972.6",
-				"@aws-sdk/util-user-agent-node": "^3.973.2",
+				"@aws-sdk/util-user-agent-node": "^3.973.0",
 				"@smithy/config-resolver": "^4.4.9",
-				"@smithy/core": "^3.23.7",
-				"@smithy/fetch-http-handler": "^5.3.12",
+				"@smithy/core": "^3.23.6",
+				"@smithy/fetch-http-handler": "^5.3.11",
 				"@smithy/hash-node": "^4.2.10",
 				"@smithy/invalid-dependency": "^4.2.10",
 				"@smithy/middleware-content-length": "^4.2.10",
-				"@smithy/middleware-endpoint": "^4.4.21",
-				"@smithy/middleware-retry": "^4.4.38",
+				"@smithy/middleware-endpoint": "^4.4.20",
+				"@smithy/middleware-retry": "^4.4.37",
 				"@smithy/middleware-serde": "^4.2.11",
 				"@smithy/middleware-stack": "^4.2.10",
 				"@smithy/node-config-provider": "^4.3.10",
-				"@smithy/node-http-handler": "^4.4.13",
+				"@smithy/node-http-handler": "^4.4.12",
 				"@smithy/protocol-http": "^5.3.10",
-				"@smithy/smithy-client": "^4.12.1",
+				"@smithy/smithy-client": "^4.12.0",
 				"@smithy/types": "^4.13.0",
 				"@smithy/url-parser": "^4.2.10",
 				"@smithy/util-base64": "^4.3.1",
 				"@smithy/util-body-length-browser": "^4.2.1",
 				"@smithy/util-body-length-node": "^4.2.2",
-				"@smithy/util-defaults-mode-browser": "^4.3.37",
-				"@smithy/util-defaults-mode-node": "^4.2.40",
+				"@smithy/util-defaults-mode-browser": "^4.3.36",
+				"@smithy/util-defaults-mode-node": "^4.2.39",
 				"@smithy/util-endpoints": "^3.3.1",
 				"@smithy/util-middleware": "^4.2.10",
 				"@smithy/util-retry": "^4.2.10",
@@ -630,13 +646,13 @@
 			}
 		},
 		"node_modules/@aws-sdk/token-providers": {
-			"version": "3.1002.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1002.0.tgz",
-			"integrity": "sha512-x972uKOydFn4Rb0PZJzLdNW59rH0KWC78Q2JbQzZpGlGt0DxjYdDRwBG6F42B1MyaEwHGqO/tkGc4r3/PRFfMw==",
+			"version": "3.1000.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1000.0.tgz",
+			"integrity": "sha512-eOI+8WPtWpLdlYBGs8OCK3k5uIMUHVsNG3AFO4kaRaZcKReJ/2OO6+2O2Dd/3vTzM56kRjSKe7mBOCwa4PdYqg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.973.17",
-				"@aws-sdk/nested-clients": "^3.996.5",
+				"@aws-sdk/core": "^3.973.15",
+				"@aws-sdk/nested-clients": "^3.996.3",
 				"@aws-sdk/types": "^3.973.4",
 				"@smithy/property-provider": "^4.2.10",
 				"@smithy/shared-ini-file-loader": "^4.4.5",
@@ -716,12 +732,12 @@
 			}
 		},
 		"node_modules/@aws-sdk/util-user-agent-node": {
-			"version": "3.973.2",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.2.tgz",
-			"integrity": "sha512-lpaIuekdkpw7VRiik0IZmd6TyvEUcuLgKZ5fKRGpCA3I4PjrD/XH15sSwW+OptxQjNU4DEzSxag70spC9SluvA==",
+			"version": "3.973.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.0.tgz",
+			"integrity": "sha512-A9J2G4Nf236e9GpaC1JnA8wRn6u6GjnOXiTwBLA6NUJhlBTIGfrTy+K1IazmF8y+4OFdW3O5TZlhyspJMqiqjA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/middleware-user-agent": "^3.972.17",
+				"@aws-sdk/middleware-user-agent": "^3.972.15",
 				"@aws-sdk/types": "^3.973.4",
 				"@smithy/node-config-provider": "^4.3.10",
 				"@smithy/types": "^4.13.0",
@@ -740,13 +756,13 @@
 			}
 		},
 		"node_modules/@aws-sdk/xml-builder": {
-			"version": "3.972.9",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.9.tgz",
-			"integrity": "sha512-ItnlMgSqkPrUfJs7EsvU/01zw5UeIb2tNPhD09LBLHbg+g+HDiKibSLwpkuz/ZIlz4F2IMn+5XgE4AK/pfPuog==",
+			"version": "3.972.8",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.8.tgz",
+			"integrity": "sha512-Ql8elcUdYCha83Ol7NznBsgN5GVZnv3vUd86fEc6waU6oUdY0T1O9NODkEEOS/Uaogr87avDrUC6DSeM4oXjZg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/types": "^4.13.0",
-				"fast-xml-parser": "5.4.1",
+				"fast-xml-parser": "5.3.6",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1224,9 +1240,9 @@
 			}
 		},
 		"node_modules/@google/genai": {
-			"version": "1.44.0",
-			"resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.44.0.tgz",
-			"integrity": "sha512-kRt9ZtuXmz+tLlcNntN/VV4LRdpl6ZOu5B1KbfNgfR65db15O6sUQcwnwLka8sT/V6qysD93fWrgJHF2L7dA9A==",
+			"version": "1.43.0",
+			"resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.43.0.tgz",
+			"integrity": "sha512-hklCsJNdMlDM1IwcCVcGQFBg2izY0+t5BIGbRsxi2UnKi6AGKL7pqJqmBDNRbw0bYCs4y3NA7TB+fkKfP/Nrdw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"google-auth-library": "^10.3.0",
@@ -1446,21 +1462,21 @@
 			}
 		},
 		"node_modules/@mariozechner/pi-agent-core": {
-			"version": "0.56.0",
-			"resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.56.0.tgz",
-			"integrity": "sha512-p8lEhONkQJgnALbkgpYd9haXcWEB32lXExvB32Y6b7JUTIdU/HIGwe8+NFVmrLrnhORbAE1ORY+3AtwtiogD4g==",
+			"version": "0.55.4",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.55.4.tgz",
+			"integrity": "sha512-g/rZMrP8X4rjqzU4kCV5LLFqOKR0jrYW3bNG7+lpENOVn6jU2GDpq8MIT2SacT76uPKQhVJII/oI9evGpnGI3w==",
 			"license": "MIT",
 			"dependencies": {
-				"@mariozechner/pi-ai": "^0.56.0"
+				"@mariozechner/pi-ai": "^0.55.4"
 			},
 			"engines": {
 				"node": ">=20.0.0"
 			}
 		},
 		"node_modules/@mariozechner/pi-ai": {
-			"version": "0.56.0",
-			"resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.56.0.tgz",
-			"integrity": "sha512-4YvTpPodywMFBMsKJfxjWJN5KcQYYc3WVvfa7mofk9Xnb6HZdFKez8wxznGWX5B6vMizvTnD4cyt/XuMcBLRFw==",
+			"version": "0.55.4",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.55.4.tgz",
+			"integrity": "sha512-q6fWN66N5wpYl/ri54v2Q3QBEz04+nBY67LmatM0xK3TKVgmeGPyQ1YXmRlyb5KhHxMDhNMxChkcHBABzfTi6g==",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.73.0",
@@ -1485,22 +1501,20 @@
 			}
 		},
 		"node_modules/@mariozechner/pi-tui": {
-			"version": "0.56.0",
-			"resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.56.0.tgz",
-			"integrity": "sha512-FZnvYvyvKJenFQqIs3iW0MGzrbOrTcAV6jFN9SFFqrjS7RDn8PkZ0iS3wZcey+2sT+YAf8AKu4f4BOXUJNB+IQ==",
+			"version": "0.55.4",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.55.4.tgz",
+			"integrity": "sha512-LXoa0CV58lEfzbjXyuUMa4KwoPTzTegPZJEEzuc9p7LnlIn4/eBebhTXQmQ7Hxo+/zb3zpy2qoynKpKcEas9GQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",
 				"chalk": "^5.5.0",
 				"get-east-asian-width": "^1.3.0",
+				"koffi": "^2.9.0",
 				"marked": "^15.0.12",
 				"mime-types": "^3.0.1"
 			},
 			"engines": {
 				"node": ">=20.0.0"
-			},
-			"optionalDependencies": {
-				"koffi": "^2.9.0"
 			}
 		},
 		"node_modules/@mistralai/mistralai": {
@@ -1986,9 +2000,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@smithy/abort-controller": {
-			"version": "4.2.11",
-			"resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.11.tgz",
-			"integrity": "sha512-Hj4WoYWMJnSpM6/kchsm4bUNTL9XiSyhvoMb2KIq4VJzyDt7JpGHUZHkVNPZVC7YE1tf8tPeVauxpFBKGW4/KQ==",
+			"version": "4.2.10",
+			"resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.10.tgz",
+			"integrity": "sha512-qocxM/X4XGATqQtUkbE9SPUB6wekBi+FyJOMbPj0AhvyvFGYEmOlz6VB22iMePCQsFmMIvFSeViDvA7mZJG47g==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/types": "^4.13.0",
@@ -1999,16 +2013,16 @@
 			}
 		},
 		"node_modules/@smithy/config-resolver": {
-			"version": "4.4.10",
-			"resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.10.tgz",
-			"integrity": "sha512-IRTkd6ps0ru+lTWnfnsbXzW80A8Od8p3pYiZnW98K2Hb20rqfsX7VTlfUwhrcOeSSy68Gn9WBofwPuw3e5CCsg==",
+			"version": "4.4.9",
+			"resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.9.tgz",
+			"integrity": "sha512-ejQvXqlcU30h7liR9fXtj7PIAau1t/sFbJpgWPfiYDs7zd16jpH0IsSXKcba2jF6ChTXvIjACs27kNMc5xxE2Q==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/node-config-provider": "^4.3.11",
+				"@smithy/node-config-provider": "^4.3.10",
 				"@smithy/types": "^4.13.0",
-				"@smithy/util-config-provider": "^4.2.2",
-				"@smithy/util-endpoints": "^3.3.2",
-				"@smithy/util-middleware": "^4.2.11",
+				"@smithy/util-config-provider": "^4.2.1",
+				"@smithy/util-endpoints": "^3.3.1",
+				"@smithy/util-middleware": "^4.2.10",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -2016,20 +2030,20 @@
 			}
 		},
 		"node_modules/@smithy/core": {
-			"version": "3.23.8",
-			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.8.tgz",
-			"integrity": "sha512-f7uPeBi7ehmLT4YF2u9j3qx6lSnurG1DLXOsTtJrIRNDF7VXio4BGHQ+SQteN/BrUVudbkuL4v7oOsRCzq4BqA==",
+			"version": "3.23.6",
+			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.6.tgz",
+			"integrity": "sha512-4xE+0L2NrsFKpEVFlFELkIHQddBvMbQ41LRIP74dGCXnY1zQ9DgksrBcRBDJT+iOzGy4VEJIeU3hkUK5mn06kg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/middleware-serde": "^4.2.12",
-				"@smithy/protocol-http": "^5.3.11",
+				"@smithy/middleware-serde": "^4.2.11",
+				"@smithy/protocol-http": "^5.3.10",
 				"@smithy/types": "^4.13.0",
-				"@smithy/util-base64": "^4.3.2",
-				"@smithy/util-body-length-browser": "^4.2.2",
-				"@smithy/util-middleware": "^4.2.11",
-				"@smithy/util-stream": "^4.5.17",
-				"@smithy/util-utf8": "^4.2.2",
-				"@smithy/uuid": "^1.1.2",
+				"@smithy/util-base64": "^4.3.1",
+				"@smithy/util-body-length-browser": "^4.2.1",
+				"@smithy/util-middleware": "^4.2.10",
+				"@smithy/util-stream": "^4.5.15",
+				"@smithy/util-utf8": "^4.2.1",
+				"@smithy/uuid": "^1.1.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -2037,15 +2051,15 @@
 			}
 		},
 		"node_modules/@smithy/credential-provider-imds": {
-			"version": "4.2.11",
-			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.11.tgz",
-			"integrity": "sha512-lBXrS6ku0kTj3xLmsJW0WwqWbGQ6ueooYyp/1L9lkyT0M02C+DWwYwc5aTyXFbRaK38ojALxNixg+LxKSHZc0g==",
+			"version": "4.2.10",
+			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.10.tgz",
+			"integrity": "sha512-3bsMLJJLTZGZqVGGeBVFfLzuRulVsGTj12BzRKODTHqUABpIr0jMN1vN3+u6r2OfyhAQ2pXaMZWX/swBK5I6PQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/node-config-provider": "^4.3.11",
-				"@smithy/property-provider": "^4.2.11",
+				"@smithy/node-config-provider": "^4.3.10",
+				"@smithy/property-provider": "^4.2.10",
 				"@smithy/types": "^4.13.0",
-				"@smithy/url-parser": "^4.2.11",
+				"@smithy/url-parser": "^4.2.10",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -2053,14 +2067,14 @@
 			}
 		},
 		"node_modules/@smithy/eventstream-codec": {
-			"version": "4.2.11",
-			"resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.11.tgz",
-			"integrity": "sha512-Sf39Ml0iVX+ba/bgMPxaXWAAFmHqYLTmbjAPfLPLY8CrYkRDEqZdUsKC1OwVMCdJXfAt0v4j49GIJ8DoSYAe6w==",
+			"version": "4.2.10",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.10.tgz",
+			"integrity": "sha512-A4ynrsFFfSXUHicfTcRehytppFBcY3HQxEGYiyGktPIOye3Ot7fxpiy4VR42WmtGI4Wfo6OXt/c1Ky1nUFxYYQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/crc32": "5.2.0",
 				"@smithy/types": "^4.13.0",
-				"@smithy/util-hex-encoding": "^4.2.2",
+				"@smithy/util-hex-encoding": "^4.2.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -2068,12 +2082,12 @@
 			}
 		},
 		"node_modules/@smithy/eventstream-serde-browser": {
-			"version": "4.2.11",
-			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.11.tgz",
-			"integrity": "sha512-3rEpo3G6f/nRS7fQDsZmxw/ius6rnlIpz4UX6FlALEzz8JoSxFmdBt0SZnthis+km7sQo6q5/3e+UJcuQivoXA==",
+			"version": "4.2.10",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.10.tgz",
+			"integrity": "sha512-0xupsu9yj9oDVuQ50YCTS9nuSYhGlrwqdaKQel9y2Fz7LU9fNErVlw9N0o4pm4qqvWEGbSTI4HKc6XJfB30MVw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/eventstream-serde-universal": "^4.2.11",
+				"@smithy/eventstream-serde-universal": "^4.2.10",
 				"@smithy/types": "^4.13.0",
 				"tslib": "^2.6.2"
 			},
@@ -2082,9 +2096,9 @@
 			}
 		},
 		"node_modules/@smithy/eventstream-serde-config-resolver": {
-			"version": "4.3.11",
-			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.11.tgz",
-			"integrity": "sha512-XeNIA8tcP/GDWnnKkO7qEm/bg0B/bP9lvIXZBXcGZwZ+VYM8h8k9wuDvUODtdQ2Wcp2RcBkPTCSMmaniVHrMlA==",
+			"version": "4.3.10",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.10.tgz",
+			"integrity": "sha512-8kn6sinrduk0yaYHMJDsNuiFpXwQwibR7n/4CDUqn4UgaG+SeBHu5jHGFdU9BLFAM7Q4/gvr9RYxBHz9/jKrhA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/types": "^4.13.0",
@@ -2095,12 +2109,12 @@
 			}
 		},
 		"node_modules/@smithy/eventstream-serde-node": {
-			"version": "4.2.11",
-			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.11.tgz",
-			"integrity": "sha512-fzbCh18rscBDTQSCrsp1fGcclLNF//nJyhjldsEl/5wCYmgpHblv5JSppQAyQI24lClsFT0wV06N1Porn0IsEw==",
+			"version": "4.2.10",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.10.tgz",
+			"integrity": "sha512-uUrxPGgIffnYfvIOUmBM5i+USdEBRTdh7mLPttjphgtooxQ8CtdO1p6K5+Q4BBAZvKlvtJ9jWyrWpBJYzBKsyQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/eventstream-serde-universal": "^4.2.11",
+				"@smithy/eventstream-serde-universal": "^4.2.10",
 				"@smithy/types": "^4.13.0",
 				"tslib": "^2.6.2"
 			},
@@ -2109,12 +2123,12 @@
 			}
 		},
 		"node_modules/@smithy/eventstream-serde-universal": {
-			"version": "4.2.11",
-			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.11.tgz",
-			"integrity": "sha512-MJ7HcI+jEkqoWT5vp+uoVaAjBrmxBtKhZTeynDRG/seEjJfqyg3SiqMMqyPnAMzmIfLaeJ/uiuSDP/l9AnMy/Q==",
+			"version": "4.2.10",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.10.tgz",
+			"integrity": "sha512-aArqzOEvcs2dK+xQVCgLbpJQGfZihw8SD4ymhkwNTtwKbnrzdhJsFDKuMQnam2kF69WzgJYOU5eJlCx+CA32bw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/eventstream-codec": "^4.2.11",
+				"@smithy/eventstream-codec": "^4.2.10",
 				"@smithy/types": "^4.13.0",
 				"tslib": "^2.6.2"
 			},
@@ -2123,15 +2137,15 @@
 			}
 		},
 		"node_modules/@smithy/fetch-http-handler": {
-			"version": "5.3.13",
-			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.13.tgz",
-			"integrity": "sha512-U2Hcfl2s3XaYjikN9cT4mPu8ybDbImV3baXR0PkVlC0TTx808bRP3FaPGAzPtB8OByI+JqJ1kyS+7GEgae7+qQ==",
+			"version": "5.3.11",
+			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.11.tgz",
+			"integrity": "sha512-wbTRjOxdFuyEg0CpumjZO0hkUl+fetJFqxNROepuLIoijQh51aMBmzFLfoQdwRjxsuuS2jizzIUTjPWgd8pd7g==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/protocol-http": "^5.3.11",
-				"@smithy/querystring-builder": "^4.2.11",
+				"@smithy/protocol-http": "^5.3.10",
+				"@smithy/querystring-builder": "^4.2.10",
 				"@smithy/types": "^4.13.0",
-				"@smithy/util-base64": "^4.3.2",
+				"@smithy/util-base64": "^4.3.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -2139,14 +2153,14 @@
 			}
 		},
 		"node_modules/@smithy/hash-node": {
-			"version": "4.2.11",
-			"resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.11.tgz",
-			"integrity": "sha512-T+p1pNynRkydpdL015ruIoyPSRw9e/SQOWmSAMmmprfswMrd5Ow5igOWNVlvyVFZlxXqGmyH3NQwfwy8r5Jx0A==",
+			"version": "4.2.10",
+			"resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.10.tgz",
+			"integrity": "sha512-1VzIOI5CcsvMDvP3iv1vG/RfLJVVVc67dCRyLSB2Hn9SWCZrDO3zvcIzj3BfEtqRW5kcMg5KAeVf1K3dR6nD3w==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/types": "^4.13.0",
-				"@smithy/util-buffer-from": "^4.2.2",
-				"@smithy/util-utf8": "^4.2.2",
+				"@smithy/util-buffer-from": "^4.2.1",
+				"@smithy/util-utf8": "^4.2.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -2154,9 +2168,9 @@
 			}
 		},
 		"node_modules/@smithy/invalid-dependency": {
-			"version": "4.2.11",
-			"resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.11.tgz",
-			"integrity": "sha512-cGNMrgykRmddrNhYy1yBdrp5GwIgEkniS7k9O1VLB38yxQtlvrxpZtUVvo6T4cKpeZsriukBuuxfJcdZQc/f/g==",
+			"version": "4.2.10",
+			"resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.10.tgz",
+			"integrity": "sha512-vy9KPNSFUU0ajFYk0sDZIYiUlAWGEAhRfehIr5ZkdFrRFTAuXEPUd41USuqHU6vvLX4r6Q9X7MKBco5+Il0Org==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/types": "^4.13.0",
@@ -2167,9 +2181,9 @@
 			}
 		},
 		"node_modules/@smithy/is-array-buffer": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
-			"integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.1.tgz",
+			"integrity": "sha512-Yfu664Qbf1B4IYIsYgKoABt010daZjkaCRvdU/sPnZG6TtHOB0md0RjNdLGzxe5UIdn9js4ftPICzmkRa9RJ4Q==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -2179,12 +2193,12 @@
 			}
 		},
 		"node_modules/@smithy/middleware-content-length": {
-			"version": "4.2.11",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.11.tgz",
-			"integrity": "sha512-UvIfKYAKhCzr4p6jFevPlKhQwyQwlJ6IeKLDhmV1PlYfcW3RL4ROjNEDtSik4NYMi9kDkH7eSwyTP3vNJ/u/Dw==",
+			"version": "4.2.10",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.10.tgz",
+			"integrity": "sha512-TQZ9kX5c6XbjhaEBpvhSvMEZ0klBs1CFtOdPFwATZSbC9UeQfKHPLPN9Y+I6wZGMOavlYTOlHEPDrt42PMSH9w==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/protocol-http": "^5.3.11",
+				"@smithy/protocol-http": "^5.3.10",
 				"@smithy/types": "^4.13.0",
 				"tslib": "^2.6.2"
 			},
@@ -2193,18 +2207,18 @@
 			}
 		},
 		"node_modules/@smithy/middleware-endpoint": {
-			"version": "4.4.22",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.22.tgz",
-			"integrity": "sha512-sc81w1o4Jy+/MAQlY3sQ8C7CmSpcvIi3TAzXblUv2hjG11BBSJi/Cw8vDx5BxMxapuH2I+Gc+45vWsgU07WZRQ==",
+			"version": "4.4.20",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.20.tgz",
+			"integrity": "sha512-9W6Np4ceBP3XCYAGLoMCmn8t2RRVzuD1ndWPLBbv7H9CrwM9Bprf6Up6BM9ZA/3alodg0b7Kf6ftBK9R1N04vw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/core": "^3.23.8",
-				"@smithy/middleware-serde": "^4.2.12",
-				"@smithy/node-config-provider": "^4.3.11",
-				"@smithy/shared-ini-file-loader": "^4.4.6",
+				"@smithy/core": "^3.23.6",
+				"@smithy/middleware-serde": "^4.2.11",
+				"@smithy/node-config-provider": "^4.3.10",
+				"@smithy/shared-ini-file-loader": "^4.4.5",
 				"@smithy/types": "^4.13.0",
-				"@smithy/url-parser": "^4.2.11",
-				"@smithy/util-middleware": "^4.2.11",
+				"@smithy/url-parser": "^4.2.10",
+				"@smithy/util-middleware": "^4.2.10",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -2212,19 +2226,19 @@
 			}
 		},
 		"node_modules/@smithy/middleware-retry": {
-			"version": "4.4.39",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.39.tgz",
-			"integrity": "sha512-MCVCxaCzuZgiHtHGV2Ke44nh6t4+8/tO+rTYOzrr2+G4nMLU/qbzNCWKBX54lyEaVcGQrfOJiG2f8imtiw+nIQ==",
+			"version": "4.4.37",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.37.tgz",
+			"integrity": "sha512-/1psZZllBBSQ7+qo5+hhLz7AEPGLx3Z0+e3ramMBEuPK2PfvLK4SrncDB9VegX5mBn+oP/UTDrM6IHrFjvX1ZA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/node-config-provider": "^4.3.11",
-				"@smithy/protocol-http": "^5.3.11",
-				"@smithy/service-error-classification": "^4.2.11",
-				"@smithy/smithy-client": "^4.12.2",
+				"@smithy/node-config-provider": "^4.3.10",
+				"@smithy/protocol-http": "^5.3.10",
+				"@smithy/service-error-classification": "^4.2.10",
+				"@smithy/smithy-client": "^4.12.0",
 				"@smithy/types": "^4.13.0",
-				"@smithy/util-middleware": "^4.2.11",
-				"@smithy/util-retry": "^4.2.11",
-				"@smithy/uuid": "^1.1.2",
+				"@smithy/util-middleware": "^4.2.10",
+				"@smithy/util-retry": "^4.2.10",
+				"@smithy/uuid": "^1.1.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -2232,12 +2246,12 @@
 			}
 		},
 		"node_modules/@smithy/middleware-serde": {
-			"version": "4.2.12",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.12.tgz",
-			"integrity": "sha512-W9g1bOLui7Xn5FABRVS0o3rXL0gfN37d/8I/W7i0N7oxjx9QecUmXEMSUMADTODwdtka9cN43t5BI2CodLJpng==",
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.11.tgz",
+			"integrity": "sha512-STQdONGPwbbC7cusL60s7vOa6He6A9w2jWhoapL0mgVjmR19pr26slV+yoSP76SIssMTX/95e5nOZ6UQv6jolg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/protocol-http": "^5.3.11",
+				"@smithy/protocol-http": "^5.3.10",
 				"@smithy/types": "^4.13.0",
 				"tslib": "^2.6.2"
 			},
@@ -2246,9 +2260,9 @@
 			}
 		},
 		"node_modules/@smithy/middleware-stack": {
-			"version": "4.2.11",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.11.tgz",
-			"integrity": "sha512-s+eenEPW6RgliDk2IhjD2hWOxIx1NKrOHxEwNUaUXxYBxIyCcDfNULZ2Mu15E3kwcJWBedTET/kEASPV1A1Akg==",
+			"version": "4.2.10",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.10.tgz",
+			"integrity": "sha512-pmts/WovNcE/tlyHa8z/groPeOtqtEpp61q3W0nW1nDJuMq/x+hWa/OVQBtgU0tBqupeXq0VBOLA4UZwE8I0YA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/types": "^4.13.0",
@@ -2259,13 +2273,13 @@
 			}
 		},
 		"node_modules/@smithy/node-config-provider": {
-			"version": "4.3.11",
-			"resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.11.tgz",
-			"integrity": "sha512-xD17eE7kaLgBBGf5CZQ58hh2YmwK1Z0O8YhffwB/De2jsL0U3JklmhVYJ9Uf37OtUDLF2gsW40Xwwag9U869Gg==",
+			"version": "4.3.10",
+			"resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.10.tgz",
+			"integrity": "sha512-UALRbJtVX34AdP2VECKVlnNgidLHA2A7YgcJzwSBg1hzmnO/bZBHl/LDQQyYifzUwp1UOODnl9JJ3KNawpUJ9w==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/property-provider": "^4.2.11",
-				"@smithy/shared-ini-file-loader": "^4.4.6",
+				"@smithy/property-provider": "^4.2.10",
+				"@smithy/shared-ini-file-loader": "^4.4.5",
 				"@smithy/types": "^4.13.0",
 				"tslib": "^2.6.2"
 			},
@@ -2274,14 +2288,14 @@
 			}
 		},
 		"node_modules/@smithy/node-http-handler": {
-			"version": "4.4.14",
-			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.14.tgz",
-			"integrity": "sha512-DamSqaU8nuk0xTJDrYnRzZndHwwRnyj/n/+RqGGCcBKB4qrQem0mSDiWdupaNWdwxzyMU91qxDmHOCazfhtO3A==",
+			"version": "4.4.12",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.12.tgz",
+			"integrity": "sha512-zo1+WKJkR9x7ZtMeMDAAsq2PufwiLDmkhcjpWPRRkmeIuOm6nq1qjFICSZbnjBvD09ei8KMo26BWxsu2BUU+5w==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/abort-controller": "^4.2.11",
-				"@smithy/protocol-http": "^5.3.11",
-				"@smithy/querystring-builder": "^4.2.11",
+				"@smithy/abort-controller": "^4.2.10",
+				"@smithy/protocol-http": "^5.3.10",
+				"@smithy/querystring-builder": "^4.2.10",
 				"@smithy/types": "^4.13.0",
 				"tslib": "^2.6.2"
 			},
@@ -2290,9 +2304,9 @@
 			}
 		},
 		"node_modules/@smithy/property-provider": {
-			"version": "4.2.11",
-			"resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.11.tgz",
-			"integrity": "sha512-14T1V64o6/ndyrnl1ze1ZhyLzIeYNN47oF/QU6P5m82AEtyOkMJTb0gO1dPubYjyyKuPD6OSVMPDKe+zioOnCg==",
+			"version": "4.2.10",
+			"resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.10.tgz",
+			"integrity": "sha512-5jm60P0CU7tom0eNrZ7YrkgBaoLFXzmqB0wVS+4uK8PPGmosSrLNf6rRd50UBvukztawZ7zyA8TxlrKpF5z9jw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/types": "^4.13.0",
@@ -2303,9 +2317,9 @@
 			}
 		},
 		"node_modules/@smithy/protocol-http": {
-			"version": "5.3.11",
-			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
-			"integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
+			"version": "5.3.10",
+			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.10.tgz",
+			"integrity": "sha512-2NzVWpYY0tRdfeCJLsgrR89KE3NTWT2wGulhNUxYlRmtRmPwLQwKzhrfVaiNlA9ZpJvbW7cjTVChYKgnkqXj1A==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/types": "^4.13.0",
@@ -2316,13 +2330,13 @@
 			}
 		},
 		"node_modules/@smithy/querystring-builder": {
-			"version": "4.2.11",
-			"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.11.tgz",
-			"integrity": "sha512-7spdikrYiljpket6u0up2Ck2mxhy7dZ0+TDd+S53Dg2DHd6wg+YNJrTCHiLdgZmEXZKI7LJZcwL3721ZRDFiqA==",
+			"version": "4.2.10",
+			"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.10.tgz",
+			"integrity": "sha512-HeN7kEvuzO2DmAzLukE9UryiUvejD3tMp9a1D1NJETerIfKobBUCLfviP6QEk500166eD2IATaXM59qgUI+YDA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/types": "^4.13.0",
-				"@smithy/util-uri-escape": "^4.2.2",
+				"@smithy/util-uri-escape": "^4.2.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -2330,9 +2344,9 @@
 			}
 		},
 		"node_modules/@smithy/querystring-parser": {
-			"version": "4.2.11",
-			"resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.11.tgz",
-			"integrity": "sha512-nE3IRNjDltvGcoThD2abTozI1dkSy8aX+a2N1Rs55en5UsdyyIXgGEmevUL3okZFoJC77JgRGe99xYohhsjivQ==",
+			"version": "4.2.10",
+			"resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.10.tgz",
+			"integrity": "sha512-4Mh18J26+ao1oX5wXJfWlTT+Q1OpDR8ssiC9PDOuEgVBGloqg18Fw7h5Ct8DyT9NBYwJgtJ2nLjKKFU6RP1G1Q==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/types": "^4.13.0",
@@ -2343,9 +2357,9 @@
 			}
 		},
 		"node_modules/@smithy/service-error-classification": {
-			"version": "4.2.11",
-			"resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.11.tgz",
-			"integrity": "sha512-HkMFJZJUhzU3HvND1+Yw/kYWXp4RPDLBWLcK1n+Vqw8xn4y2YiBhdww8IxhkQjP/QlZun5bwm3vcHc8AqIU3zw==",
+			"version": "4.2.10",
+			"resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.10.tgz",
+			"integrity": "sha512-0R/+/Il5y8nB/By90o8hy/bWVYptbIfvoTYad0igYQO5RefhNCDmNzqxaMx7K1t/QWo0d6UynqpqN5cCQt1MCg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/types": "^4.13.0"
@@ -2355,9 +2369,9 @@
 			}
 		},
 		"node_modules/@smithy/shared-ini-file-loader": {
-			"version": "4.4.6",
-			"resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.6.tgz",
-			"integrity": "sha512-IB/M5I8G0EeXZTHsAxpx51tMQ5R719F3aq+fjEB6VtNcCHDc0ajFDIGDZw+FW9GxtEkgTduiPpjveJdA/CX7sw==",
+			"version": "4.4.5",
+			"resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.5.tgz",
+			"integrity": "sha512-pHgASxl50rrtOztgQCPmOXFjRW+mCd7ALr/3uXNzRrRoGV5G2+78GOsQ3HlQuBVHCh9o6xqMNvlIKZjWn4Euug==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/types": "^4.13.0",
@@ -2368,18 +2382,18 @@
 			}
 		},
 		"node_modules/@smithy/signature-v4": {
-			"version": "5.3.11",
-			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.11.tgz",
-			"integrity": "sha512-V1L6N9aKOBAN4wEHLyqjLBnAz13mtILU0SeDrjOaIZEeN6IFa6DxwRt1NNpOdmSpQUfkBj0qeD3m6P77uzMhgQ==",
+			"version": "5.3.10",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.10.tgz",
+			"integrity": "sha512-Wab3wW8468WqTKIxI+aZe3JYO52/RYT/8sDOdzkUhjnLakLe9qoQqIcfih/qxcF4qWEFoWBszY0mj5uxffaVXA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/is-array-buffer": "^4.2.2",
-				"@smithy/protocol-http": "^5.3.11",
+				"@smithy/is-array-buffer": "^4.2.1",
+				"@smithy/protocol-http": "^5.3.10",
 				"@smithy/types": "^4.13.0",
-				"@smithy/util-hex-encoding": "^4.2.2",
-				"@smithy/util-middleware": "^4.2.11",
-				"@smithy/util-uri-escape": "^4.2.2",
-				"@smithy/util-utf8": "^4.2.2",
+				"@smithy/util-hex-encoding": "^4.2.1",
+				"@smithy/util-middleware": "^4.2.10",
+				"@smithy/util-uri-escape": "^4.2.1",
+				"@smithy/util-utf8": "^4.2.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -2387,17 +2401,17 @@
 			}
 		},
 		"node_modules/@smithy/smithy-client": {
-			"version": "4.12.2",
-			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.2.tgz",
-			"integrity": "sha512-HezY3UuG0k4T+4xhFKctLXCA5N2oN+Rtv+mmL8Gt7YmsUY2yhmcLyW75qrSzldfj75IsCW/4UhY3s20KcFnZqA==",
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.0.tgz",
+			"integrity": "sha512-R8bQ9K3lCcXyZmBnQqUZJF4ChZmtWT5NLi6x5kgWx5D+/j0KorXcA0YcFg/X5TOgnTCy1tbKc6z2g2y4amFupQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/core": "^3.23.8",
-				"@smithy/middleware-endpoint": "^4.4.22",
-				"@smithy/middleware-stack": "^4.2.11",
-				"@smithy/protocol-http": "^5.3.11",
+				"@smithy/core": "^3.23.6",
+				"@smithy/middleware-endpoint": "^4.4.20",
+				"@smithy/middleware-stack": "^4.2.10",
+				"@smithy/protocol-http": "^5.3.10",
 				"@smithy/types": "^4.13.0",
-				"@smithy/util-stream": "^4.5.17",
+				"@smithy/util-stream": "^4.5.15",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -2417,12 +2431,12 @@
 			}
 		},
 		"node_modules/@smithy/url-parser": {
-			"version": "4.2.11",
-			"resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.11.tgz",
-			"integrity": "sha512-oTAGGHo8ZYc5VZsBREzuf5lf2pAurJQsccMusVZ85wDkX66ojEc/XauiGjzCj50A61ObFTPe6d7Pyt6UBYaing==",
+			"version": "4.2.10",
+			"resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.10.tgz",
+			"integrity": "sha512-uypjF7fCDsRk26u3qHmFI/ePL7bxxB9vKkE+2WKEciHhz+4QtbzWiHRVNRJwU3cKhrYDYQE3b0MRFtqfLYdA4A==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/querystring-parser": "^4.2.11",
+				"@smithy/querystring-parser": "^4.2.10",
 				"@smithy/types": "^4.13.0",
 				"tslib": "^2.6.2"
 			},
@@ -2431,13 +2445,13 @@
 			}
 		},
 		"node_modules/@smithy/util-base64": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
-			"integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.1.tgz",
+			"integrity": "sha512-BKGuawX4Doq/bI/uEmg+Zyc36rJKWuin3py89PquXBIBqmbnJwBBsmKhdHfNEp0+A4TDgLmT/3MSKZ1SxHcR6w==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/util-buffer-from": "^4.2.2",
-				"@smithy/util-utf8": "^4.2.2",
+				"@smithy/util-buffer-from": "^4.2.1",
+				"@smithy/util-utf8": "^4.2.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -2445,9 +2459,9 @@
 			}
 		},
 		"node_modules/@smithy/util-body-length-browser": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
-			"integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.1.tgz",
+			"integrity": "sha512-SiJeLiozrAoCrgDBUgsVbmqHmMgg/2bA15AzcbcW+zan7SuyAVHN4xTSbq0GlebAIwlcaX32xacnrG488/J/6g==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -2457,9 +2471,9 @@
 			}
 		},
 		"node_modules/@smithy/util-body-length-node": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
-			"integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.2.tgz",
+			"integrity": "sha512-4rHqBvxtJEBvsZcFQSPQqXP2b/yy/YlB66KlcEgcH2WNoOKCKB03DSLzXmOsXjbl8dJ4OEYTn31knhdznwk7zw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -2469,12 +2483,12 @@
 			}
 		},
 		"node_modules/@smithy/util-buffer-from": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
-			"integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.1.tgz",
+			"integrity": "sha512-/swhmt1qTiVkaejlmMPPDgZhEaWb/HWMGRBheaxwuVkusp/z+ErJyQxO6kaXumOciZSWlmq6Z5mNylCd33X7Ig==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/is-array-buffer": "^4.2.2",
+				"@smithy/is-array-buffer": "^4.2.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -2482,9 +2496,9 @@
 			}
 		},
 		"node_modules/@smithy/util-config-provider": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
-			"integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.1.tgz",
+			"integrity": "sha512-462id/00U8JWFw6qBuTSWfN5TxOHvDu4WliI97qOIOnuC/g+NDAknTU8eoGXEPlLkRVgWEr03jJBLV4o2FL8+A==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -2494,13 +2508,13 @@
 			}
 		},
 		"node_modules/@smithy/util-defaults-mode-browser": {
-			"version": "4.3.38",
-			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.38.tgz",
-			"integrity": "sha512-c8P1mFLNxcsdAMabB8/VUQUbWzFmgujWi4bAXSggcqLYPc8V4U5abqFqOyn+dK4YT+q8UyCVkTO8807t4t2syA==",
+			"version": "4.3.36",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.36.tgz",
+			"integrity": "sha512-R0smq7EHQXRVMxkAxtH5akJ/FvgAmNF6bUy/GwY/N20T4GrwjT633NFm0VuRpC+8Bbv8R9A0DoJ9OiZL/M3xew==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/property-provider": "^4.2.11",
-				"@smithy/smithy-client": "^4.12.2",
+				"@smithy/property-provider": "^4.2.10",
+				"@smithy/smithy-client": "^4.12.0",
 				"@smithy/types": "^4.13.0",
 				"tslib": "^2.6.2"
 			},
@@ -2509,16 +2523,16 @@
 			}
 		},
 		"node_modules/@smithy/util-defaults-mode-node": {
-			"version": "4.2.41",
-			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.41.tgz",
-			"integrity": "sha512-/UG+9MT3UZAR0fLzOtMJMfWGcjjHvgggq924x/CRy8vRbL+yFf3Z6vETlvq8vDH92+31P/1gSOFoo7303wN8WQ==",
+			"version": "4.2.39",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.39.tgz",
+			"integrity": "sha512-otWuoDm35btJV1L8MyHrPl462B07QCdMTktKc7/yM+Psv6KbED/ziXiHnmr7yPHUjfIwE9S8Max0LO24Mo3ZVg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/config-resolver": "^4.4.10",
-				"@smithy/credential-provider-imds": "^4.2.11",
-				"@smithy/node-config-provider": "^4.3.11",
-				"@smithy/property-provider": "^4.2.11",
-				"@smithy/smithy-client": "^4.12.2",
+				"@smithy/config-resolver": "^4.4.9",
+				"@smithy/credential-provider-imds": "^4.2.10",
+				"@smithy/node-config-provider": "^4.3.10",
+				"@smithy/property-provider": "^4.2.10",
+				"@smithy/smithy-client": "^4.12.0",
 				"@smithy/types": "^4.13.0",
 				"tslib": "^2.6.2"
 			},
@@ -2527,12 +2541,12 @@
 			}
 		},
 		"node_modules/@smithy/util-endpoints": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.3.2.tgz",
-			"integrity": "sha512-+4HFLpE5u29AbFlTdlKIT7jfOzZ8PDYZKTb3e+AgLz986OYwqTourQ5H+jg79/66DB69Un1+qKecLnkZdAsYcA==",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.3.1.tgz",
+			"integrity": "sha512-xyctc4klmjmieQiF9I1wssBWleRV0RhJ2DpO8+8yzi2LO1Z+4IWOZNGZGNj4+hq9kdo+nyfrRLmQTzc16Op2Vg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/node-config-provider": "^4.3.11",
+				"@smithy/node-config-provider": "^4.3.10",
 				"@smithy/types": "^4.13.0",
 				"tslib": "^2.6.2"
 			},
@@ -2541,9 +2555,9 @@
 			}
 		},
 		"node_modules/@smithy/util-hex-encoding": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
-			"integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.1.tgz",
+			"integrity": "sha512-c1hHtkgAWmE35/50gmdKajgGAKV3ePJ7t6UtEmpfCWJmQE9BQAQPz0URUVI89eSkcDqCtzqllxzG28IQoZPvwA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -2553,9 +2567,9 @@
 			}
 		},
 		"node_modules/@smithy/util-middleware": {
-			"version": "4.2.11",
-			"resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.11.tgz",
-			"integrity": "sha512-r3dtF9F+TpSZUxpOVVtPfk09Rlo4lT6ORBqEvX3IBT6SkQAdDSVKR5GcfmZbtl7WKhKnmb3wbDTQ6ibR2XHClw==",
+			"version": "4.2.10",
+			"resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.10.tgz",
+			"integrity": "sha512-LxaQIWLp4y0r72eA8mwPNQ9va4h5KeLM0I3M/HV9klmFaY2kN766wf5vsTzmaOpNNb7GgXAd9a25P3h8T49PSA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/types": "^4.13.0",
@@ -2566,12 +2580,12 @@
 			}
 		},
 		"node_modules/@smithy/util-retry": {
-			"version": "4.2.11",
-			"resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.11.tgz",
-			"integrity": "sha512-XSZULmL5x6aCTTii59wJqKsY1l3eMIAomRAccW7Tzh9r8s7T/7rdo03oektuH5jeYRlJMPcNP92EuRDvk9aXbw==",
+			"version": "4.2.10",
+			"resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.10.tgz",
+			"integrity": "sha512-HrBzistfpyE5uqTwiyLsFHscgnwB0kgv8vySp7q5kZ0Eltn/tjosaSGGDj/jJ9ys7pWzIP/icE2d+7vMKXLv7A==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/service-error-classification": "^4.2.11",
+				"@smithy/service-error-classification": "^4.2.10",
 				"@smithy/types": "^4.13.0",
 				"tslib": "^2.6.2"
 			},
@@ -2580,18 +2594,18 @@
 			}
 		},
 		"node_modules/@smithy/util-stream": {
-			"version": "4.5.17",
-			"resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.17.tgz",
-			"integrity": "sha512-793BYZ4h2JAQkNHcEnyFxDTcZbm9bVybD0UV/LEWmZ5bkTms7JqjfrLMi2Qy0E5WFcCzLwCAPgcvcvxoeALbAQ==",
+			"version": "4.5.15",
+			"resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.15.tgz",
+			"integrity": "sha512-OlOKnaqnkU9X+6wEkd7mN+WB7orPbCVDauXOj22Q7VtiTkvy7ZdSsOg4QiNAZMgI4OkvNf+/VLUC3VXkxuWJZw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/fetch-http-handler": "^5.3.13",
-				"@smithy/node-http-handler": "^4.4.14",
+				"@smithy/fetch-http-handler": "^5.3.11",
+				"@smithy/node-http-handler": "^4.4.12",
 				"@smithy/types": "^4.13.0",
-				"@smithy/util-base64": "^4.3.2",
-				"@smithy/util-buffer-from": "^4.2.2",
-				"@smithy/util-hex-encoding": "^4.2.2",
-				"@smithy/util-utf8": "^4.2.2",
+				"@smithy/util-base64": "^4.3.1",
+				"@smithy/util-buffer-from": "^4.2.1",
+				"@smithy/util-hex-encoding": "^4.2.1",
+				"@smithy/util-utf8": "^4.2.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -2599,9 +2613,9 @@
 			}
 		},
 		"node_modules/@smithy/util-uri-escape": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
-			"integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.1.tgz",
+			"integrity": "sha512-YmiUDn2eo2IOiWYYvGQkgX5ZkBSiTQu4FlDo5jNPpAxng2t6Sjb6WutnZV9l6VR4eJul1ABmCrnWBC9hKHQa6Q==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -2611,12 +2625,12 @@
 			}
 		},
 		"node_modules/@smithy/util-utf8": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
-			"integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.1.tgz",
+			"integrity": "sha512-DSIwNaWtmzrNQHv8g7DBGR9mulSit65KSj5ymGEIAknmIN8IpbZefEep10LaMG/P/xquwbmJ1h9ectz8z6mV6g==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/util-buffer-from": "^4.2.2",
+				"@smithy/util-buffer-from": "^4.2.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -2624,9 +2638,9 @@
 			}
 		},
 		"node_modules/@smithy/uuid": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
-			"integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.1.tgz",
+			"integrity": "sha512-dSfDCeihDmZlV2oyr0yWPTUfh07suS+R5OB+FZGiv/hHyK3hrFBW5rR1UYjfa57vBsrP9lciFkRPzebaV1Qujw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -2910,15 +2924,12 @@
 			}
 		},
 		"node_modules/ansi-regex": {
-			"version": "6.2.2",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
 			"license": "MIT",
 			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+				"node": ">=8"
 			}
 		},
 		"node_modules/ansi-styles": {
@@ -3152,27 +3163,6 @@
 				"string-width": "^4.2.0",
 				"strip-ansi": "^6.0.0",
 				"wrap-ansi": "^7.0.0"
-			}
-		},
-		"node_modules/cliui/node_modules/ansi-regex": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/cliui/node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/color-convert": {
@@ -3520,22 +3510,10 @@
 			],
 			"license": "BSD-3-Clause"
 		},
-		"node_modules/fast-xml-builder": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.0.0.tgz",
-			"integrity": "sha512-fpZuDogrAgnyt9oDDz+5DBz0zgPdPZz6D4IR7iESxRXElrlGTRkHJ9eEt+SACRJwT0FNFrt71DFQIUFBJfX/uQ==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/NaturalIntelligence"
-				}
-			],
-			"license": "MIT"
-		},
 		"node_modules/fast-xml-parser": {
-			"version": "5.4.1",
-			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.4.1.tgz",
-			"integrity": "sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==",
+			"version": "5.3.6",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.6.tgz",
+			"integrity": "sha512-QNI3sAvSvaOiaMl8FYU4trnEzCwiRr8XMWgAHzlrWpTSj+QaCSvOf1h82OEP1s4hiAXhnbXSyFWCf4ldZzZRVA==",
 			"funding": [
 				{
 					"type": "github",
@@ -3544,7 +3522,6 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"fast-xml-builder": "^1.0.0",
 				"strnum": "^2.1.2"
 			},
 			"bin": {
@@ -4065,7 +4042,6 @@
 			"integrity": "sha512-mnc0C0crx/xMSljb5s9QbnLrlFHprioFO1hkXyuSuO/QtbpLDa0l/uM21944UfQunMKmp3/r789DTDxVyyH6aA==",
 			"hasInstallScript": true,
 			"license": "MIT",
-			"optional": true,
 			"funding": {
 				"url": "https://liberapay.com/Koromix"
 			}
@@ -4993,16 +4969,7 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/string-width/node_modules/ansi-regex": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/string-width/node_modules/strip-ansi": {
+		"node_modules/strip-ansi": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
@@ -5012,21 +4979,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/strip-ansi": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^6.2.2"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
 			}
 		},
 		"node_modules/strip-eof": {
@@ -5573,27 +5525,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-			}
-		},
-		"node_modules/wrap-ansi/node_modules/ansi-regex": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/wrap-ansi/node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/wrappy": {


### PR DESCRIPTION
pi 0.56.0 introduced a regression in the extension loader where jiti alias targets are bare specifiers instead of absolute paths. This breaks module resolution for extensions outside pi's own node_modules tree (e.g. ~/.pi/agent/extensions/).

The fix is already on pi-mono main (resolveWorkspaceOrSpecifier -> resolveWorkspaceOrImport using import.meta.resolve()), so this revert can be dropped on the next pi release.

Ref: https://github.com/badlogic/pi-mono/issues/1814

## Summary

<!-- Briefly describe what this PR does -->

## Test plan

<!-- How did you test this change? -->

- [ ] `nix build .#<package>` succeeds
- [ ] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
