### PR TITLE
update claude-desktop to aaddrick/claude-desktop-debian, which is more actively maintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -874,7 +874,7 @@ Contributions are welcome! Please:
 ## See also
 
 - [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) - Nix packages for MCP (Model Context Protocol) servers
-- [k3d3/claude-desktop-linux-flake](https://github.com/k3d3/claude-desktop-linux-flake) - Claude Desktop for Linux
+- [aaddrick/claude-desktop-debian](https://github.com/aaddrick/claude-desktop-debian?tab=readme-ov-file#using-nix-flake-nixos) - Claude Desktop for Linux
 
 ## License
 


### PR DESCRIPTION
## Summary

When I try to install the claude desktop on nixos, found the link in the README.md, though after some check, seems it's outdated

- https://github.com/k3d3/claude-desktop-linux-flake hasn't been updated for 4 months
- https://github.com/aaddrick/claude-desktop-debian is updating quite actively, and also support nix as flake

## Test plan

I did install aaddrick/claude-desktop-debian with nix flakes, it works nicely.

