### PR TITLE
vibe-kanban: 0.1.2 -> 0.1.27

### DIFF
--- a/packages/vibe-kanban/hashes.json
+++ b/packages/vibe-kanban/hashes.json
@@ -1,8 +1,8 @@
 {
-  "version": "0.1.2",
-  "tag": "v0.1.2-20260203101746",
-  "hash": "sha256-rC9r9UPkI75vf4Fk1snBz5KDf/U8lw6XrO2nF8gplpo=",
-  "cargoHash": "sha256-IIpLTlHfDhMTwaUwNEGECQXnsWmPpibt6FkO8smrnBA=",
-  "npmDepsHash": "sha256-wY/ATOO3OcUc72ScmHradTnwBG7PZOqIFrTdHSAAY+8=",
-  "releaseZipHash": "sha256-dDoRqox1WQF6zqUJg859/1USpEEQ/uLlPO5Q6DQmfyg="
+  "version": "0.1.27",
+  "tag": "v0.1.27-20260309171359",
+  "hash": "sha256-5WLxhte9dCSsmj8srgbxGMJd4zB056MPviwaZavkAiU=",
+  "cargoHash": "sha256-0e2fN4t+dQNTAjIdUGPYCgdS0VPJUTjhVbVrW+D+Cns=",
+  "npmDepsHash": "sha256-7d48V4IV3jlD2iPfR+gCNTSA7k4TsxLhu0Q5fjjVJoc=",
+  "releaseZipHash": "sha256-IEyhAktvdktYTXp6MX9TaembGVZQvD4uTTyodbtik7s="
 }

--- a/packages/vibe-kanban/package.nix
+++ b/packages/vibe-kanban/package.nix
@@ -10,7 +10,7 @@
   pnpmConfigHook,
   nodejs-slim,
   pkg-config,
-  openssl,
+  cmake,
   libgit2,
   sqlite,
   llvmPackages,
@@ -44,6 +44,7 @@ let
   };
 
   # Phase 1: Build frontend
+  # The project is a pnpm monorepo; the frontend lives at packages/local-web/
   frontend = stdenv.mkDerivation {
     pname = "vibe-kanban-frontend";
     inherit version src;
@@ -75,15 +76,16 @@ let
           | cut -d'"' -f2
       )
 
-      cd frontend
-      pnpm build
+      export VITE_VK_SHARED_API_BASE="https://api.vibekanban.com"
+
+      pnpm --filter @vibe/local-web run build
       runHook postBuild
     '';
 
     installPhase = ''
       runHook preInstall
       mkdir -p $out
-      cp -r dist/* $out/
+      cp -r packages/local-web/dist/* $out/
       runHook postInstall
     '';
   };
@@ -99,22 +101,25 @@ rustPlatform.buildRustPackage {
     "server"
     "--package"
     "review"
+    "--package"
+    "mcp"
   ];
 
   nativeBuildInputs = [
     pkg-config
+    cmake
     llvmPackages.libclang
   ];
   buildInputs = [
-    openssl
     libgit2
     sqlite
   ];
 
-  # Copy frontend assets before Rust build
+  # Copy frontend assets where rust-embed expects them
+  # (crates/server references ../../packages/local-web/dist)
   preBuild = ''
-    mkdir -p frontend/dist
-    cp -r ${frontend}/* frontend/dist/
+    mkdir -p packages/local-web/dist
+    cp -r ${frontend}/* packages/local-web/dist/
   '';
 
   env = {
@@ -126,8 +131,8 @@ rustPlatform.buildRustPackage {
 
   postInstall = ''
     mv $out/bin/server $out/bin/vibe-kanban
-    mv $out/bin/mcp_task_server $out/bin/vibe-kanban-mcp
     mv $out/bin/review $out/bin/vibe-kanban-review
+    # mcp crate already outputs binary named "vibe-kanban-mcp", no rename needed
     rm -f $out/bin/generate_types
     rm -rf $out/bin/*.dSYM
   '';


### PR DESCRIPTION
- Update to v0.1.27-20260309171359
- Fix frontend build for pnpm monorepo (packages/local-web/)
- Add mcp crate to cargo build targets
- Replace openssl with cmake (upstream switched to rustls/aws_lc_rs)
- Fix frontend asset path for rust-embed (packages/local-web/dist)
- Update postInstall for renamed mcp binary
- Set VITE_VK_SHARED_API_BASE env var

## Summary

<!-- Briefly describe what this PR does -->

## Test plan

<!-- How did you test this change? -->

- [ ] `nix build .#<package>` succeeds
- [ ] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
