### PR TITLE
go-bin: init at 1.25.8, use for beads

### DIFF
--- a/packages/beads/default.nix
+++ b/packages/beads/default.nix
@@ -4,5 +4,5 @@
   ...
 }:
 pkgs.callPackage ./package.nix {
-  inherit (perSystem.self) unpinGoModVersionHook;
+  inherit (perSystem.self) go-bin;
 }

--- a/packages/beads/package.nix
+++ b/packages/beads/package.nix
@@ -4,25 +4,24 @@
   fetchFromGitHub,
   makeWrapper,
   dolt,
-  unpinGoModVersionHook,
+  go-bin,
   versionCheckHook,
 }:
 
-buildGoModule rec {
+buildGoModule.override { go = go-bin; } rec {
   pname = "beads";
-  version = "0.59.0";
+  version = "0.60.0";
 
   src = fetchFromGitHub {
     owner = "steveyegge";
     repo = "beads";
     rev = "v${version}";
-    hash = "sha256-IyO0RWP98NQ8GHVsolhu80FS06aqrZjg0JprDiFdyCk=";
+    hash = "sha256-z3EDtaBHB3ltPRT7vuBFURD7UwgAJBXAPozRnkjejeU=";
   };
 
-  vendorHash = "sha256-ygZPi56fVEHaEShGVGpObFkrLs1DHrM8i2Y4BktMmpA=";
+  vendorHash = "sha256-1BJsEPP5SYZFGCWHLn532IUKlzcGDg5nhrqGWylEHgY=";
 
   nativeBuildInputs = [
-    unpinGoModVersionHook
     makeWrapper
   ];
 

--- a/packages/go-bin/default.nix
+++ b/packages/go-bin/default.nix
@@ -1,0 +1,1 @@
+{ pkgs, ... }: pkgs.callPackage ./package.nix { }

--- a/packages/go-bin/hashes.json
+++ b/packages/go-bin/hashes.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.25.8",
+  "hashes": {
+    "darwin-amd64": "sha256-oLgTZZi68ZKvQABRzuJIH/tAf0wROoH/QAiW4my86eQ=",
+    "darwin-arm64": "sha256-xlR5WfXb6EQL89qXK9ZbqQAWjeXnqwFGT73HrIN1whw=",
+    "linux-amd64": "sha256-zrXgQbvDiThGvRYU12y0aByR2t7leUJs8hpj8tfgO+Y=",
+    "linux-arm64": "sha256-fRN/WfZruT9AprKxHnE63CqdDI2a5YFxjj+tGeUpXcc="
+  }
+}

--- a/packages/go-bin/package.nix
+++ b/packages/go-bin/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+}:
+
+let
+  versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
+  inherit (versionData) version hashes;
+
+  platform = with stdenv.hostPlatform.go; "${GOOS}-${if GOARCH == "arm" then "armv6l" else GOARCH}";
+in
+stdenv.mkDerivation {
+  pname = "go-bin";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://go.dev/dl/go${version}.${platform}.tar.gz";
+    hash = hashes.${platform} or (throw "Missing Go hash for platform ${platform}");
+  };
+
+  # Preserve code signature on Darwin
+  dontStrip = stdenv.hostPlatform.isDarwin;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/go $out/bin
+    cp -r . $out/share/go
+    ln -s $out/share/go/bin/go $out/bin/go
+    ln -s $out/share/go/bin/gofmt $out/bin/gofmt
+    runHook postInstall
+  '';
+
+  # buildGoModule reads these attributes from the `go` package.
+  inherit (stdenv.hostPlatform.go) GOOS GOARCH;
+  CGO_ENABLED = 1;
+
+  passthru.hideFromDocs = true;
+
+  meta = {
+    description = "Latest Go toolchain (prebuilt binary) for building packages that need a newer patch release than nixpkgs ships";
+    homepage = "https://go.dev/";
+    license = lib.licenses.bsd3;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    platforms = lib.platforms.darwin ++ lib.platforms.linux;
+  };
+}

--- a/packages/go-bin/update.py
+++ b/packages/go-bin/update.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env nix
+#! nix shell --inputs-from .# nixpkgs#python3 --command python3
+
+"""Update script for go-bin package.
+
+Fetches the latest patch release of the Go minor version we track from the
+official Go download API and updates hashes.json.
+"""
+
+import base64
+import sys
+from pathlib import Path
+from typing import Any, cast
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+
+from updater import (
+    fetch_json,
+    load_hashes,
+    save_hashes,
+    should_update,
+)
+
+HASHES_FILE = Path(__file__).parent / "hashes.json"
+
+# Platforms we package, as <os>-<arch> matching Go download filenames.
+PLATFORMS = ("linux-amd64", "linux-arm64", "darwin-amd64", "darwin-arm64")
+
+
+def minor_version(v: str) -> str:
+    """Return the major.minor portion of a version string."""
+    parts = v.split(".")
+    return f"{parts[0]}.{parts[1]}"
+
+
+def fetch_latest_go_release(minor: str) -> dict[str, Any] | None:
+    """Find the latest stable release for a Go minor version.
+
+    The Go download API returns releases newest-first, so the first
+    match for our minor wins.
+    """
+    data = fetch_json("https://go.dev/dl/?mode=json")
+    if not isinstance(data, list):
+        msg = f"Expected list from Go API, got {type(data)}"
+        raise TypeError(msg)
+    for release in data:
+        ver = cast("str", release["version"]).removeprefix("go")
+        if minor_version(ver) == minor and release.get("stable", False):
+            return cast("dict[str, Any]", release)
+    return None
+
+
+def sha256_hex_to_sri(hex_hash: str) -> str:
+    """Convert a hex sha256 to SRI format (sha256-<base64>)."""
+    raw = bytes.fromhex(hex_hash)
+    return f"sha256-{base64.b64encode(raw).decode()}"
+
+
+def extract_platform_hashes(release: dict[str, Any]) -> dict[str, str]:
+    """Extract SRI sha256 hashes for each platform from a Go release."""
+    hashes: dict[str, str] = {}
+    for f in release["files"]:
+        if f["kind"] != "archive":
+            continue
+        key = f"{f['os']}-{f['arch']}"
+        if key in PLATFORMS:
+            hashes[key] = sha256_hex_to_sri(f["sha256"])
+    missing = set(PLATFORMS) - set(hashes)
+    if missing:
+        msg = f"Missing hashes for platforms: {missing}"
+        raise ValueError(msg)
+    return hashes
+
+
+def main() -> None:
+    """Update the go-bin package."""
+    data = load_hashes(HASHES_FILE)
+    current = data["version"]
+    minor = minor_version(current)
+
+    print(f"Current: {current}, tracking Go {minor}.x")
+
+    release = fetch_latest_go_release(minor)
+    if release is None:
+        print(f"No stable release found for Go {minor}")
+        return
+
+    latest = cast("str", release["version"]).removeprefix("go")
+    print(f"Latest: {latest}")
+
+    if not should_update(current, latest):
+        print("Already up to date")
+        return
+
+    print("Extracting platform hashes...")
+    hashes = extract_platform_hashes(release)
+    for plat, h in sorted(hashes.items()):
+        print(f"  {plat}: {h}")
+
+    save_hashes(HASHES_FILE, {"version": latest, "hashes": hashes})
+    print(f"Updated to {latest}")
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/unpinGoModVersionHook/unpin-go-mod-version.sh
+++ b/packages/unpinGoModVersionHook/unpin-go-mod-version.sh
@@ -1,7 +1,17 @@
 # shellcheck shell=bash
 # Setup hook that relaxes go.mod version constraints to match the Go toolchain
-# used by the build. This prevents "go.mod requires go >= X.Y.Z" errors when
+# used by the build.  This prevents "go.mod requires go >= X.Y.Z" errors when
 # upstream pins a newer patch version than nixpkgs ships.
+#
+# What this hook does:
+#   1. Patches the go directive in go.mod to match the running Go version.
+#   2. Removes the toolchain directive so Go does not try to switch toolchains.
+#
+# This is sufficient when the *top-level* go.mod is the only one that pins a
+# newer version.  When transitive dependencies also require a newer Go, use
+# go-bin (our prebuilt latest-patch Go package) instead:
+#
+#   buildGoModule.override { go = go-bin; }
 
 unpinGoModVersion() {
   if [[ ! -f go.mod ]]; then
@@ -10,7 +20,6 @@ unpinGoModVersion() {
 
   local goVersion
   goVersion="$(go env GOVERSION)"
-  # go env GOVERSION returns e.g. "go1.25.5" – strip the "go" prefix
   goVersion="${goVersion#go}"
 
   echo "unpinGoModVersionHook: setting go.mod go directive to $goVersion"


### PR DESCRIPTION

Add a prebuilt Go toolchain package (go-bin) that tracks the latest
patch release of the Go minor version we need.  This avoids the
GOTOOLCHAIN=local version mismatch that breaks builds when nixpkgs
ships an older patch (e.g. 1.25.7) but upstream go.mod or its
transitive dependencies require a newer one (1.25.8).

Switch beads from unpinGoModVersionHook to go-bin since the hook can
only patch the top-level go.mod — it cannot satisfy version constraints
imposed by transitive dependencies like charm.land/huh/v2.

Update unpinGoModVersionHook docs to recommend go-bin for the
transitive-dependency case.
