### PR TITLE
packages: add firefox-bench to populate cache for nix copy benchmarks

### DIFF
--- a/packages/firefox-bench/default.nix
+++ b/packages/firefox-bench/default.nix
@@ -1,0 +1,4 @@
+# Dummy package to populate firefox into cache.numtide.com for benchmarking.
+# See: https://gist.github.com/Mic92/ef30813962725d922b68ea13f000c615
+{ pkgs, ... }:
+pkgs.firefox


### PR DESCRIPTION
See https://gist.github.com/Mic92/ef30813962725d922b68ea13f000c615 for the benchmark comparing sequential vs parallel addMultipleToStore.

## Summary

<!-- Briefly describe what this PR does -->

## Test plan

<!-- How did you test this change? -->

- [ ] `nix build .#<package>` succeeds
- [ ] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
