### PR TITLE
showboat: init at 0.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -723,6 +723,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 - **Nix**: [packages/rtk/package.nix](packages/rtk/package.nix)
 
 </details>
+<details>
+<summary><strong>showboat</strong> - Create executable demo documents showing and proving an agent's work</summary>
+
+- **Source**: source
+- **License**: Apache-2.0
+- **Homepage**: https://github.com/simonw/showboat
+- **Usage**: `nix run github:numtide/llm-agents.nix#showboat -- --help`
+- **Nix**: [packages/showboat/package.nix](packages/showboat/package.nix)
+
+</details>
 <!-- END GENERATED PACKAGE DOCS -->
 
 ## Installation

--- a/packages/showboat/default.nix
+++ b/packages/showboat/default.nix
@@ -1,0 +1,8 @@
+{
+  pkgs,
+  flake,
+  ...
+}:
+pkgs.callPackage ./package.nix {
+  inherit flake;
+}

--- a/packages/showboat/package.nix
+++ b/packages/showboat/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  flake,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+}:
+
+buildGoModule rec {
+  pname = "showboat";
+  version = "0.6.1";
+
+  src = fetchFromGitHub {
+    owner = "simonw";
+    repo = "showboat";
+    rev = "v${version}";
+    hash = "sha256-yYK6j6j7OgLABHLOSKlzNnm2AWzM2Ig76RJypBsBnkI=";
+  };
+
+  vendorHash = "sha256-mGKxBRU5TPgdmiSx0DHEd0Ys8gsVD/YdBfbDdSVpC3U=";
+
+  subPackages = [ "." ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X=main.version=${version}"
+  ];
+
+  # Tests require python3 and other executors in PATH
+  doCheck = false;
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.category = "Utilities";
+
+  meta = with lib; {
+    description = "Create executable demo documents showing and proving an agent's work";
+    homepage = "https://github.com/simonw/showboat";
+    changelog = "https://github.com/simonw/showboat/releases/tag/v${version}";
+    license = licenses.asl20;
+    sourceProvenance = with sourceTypes; [ fromSource ];
+    maintainers = with flake.lib.maintainers; [ jfroche ];
+    mainProgram = "showboat";
+    platforms = platforms.unix;
+  };
+}


### PR DESCRIPTION
Add [showboat](https://github.com/simonw/showboat), a go cli tool that helps you create documents that show and prove an agent's work.

## Test plan

- [x] `nix build .#showboat` succeeds
- [x] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work
