### PR TITLE
sidecar: init at 0.78.0

### DIFF
--- a/packages/sidecar/default.nix
+++ b/packages/sidecar/default.nix
@@ -1,0 +1,8 @@
+{
+  pkgs,
+  flake,
+  ...
+}:
+pkgs.callPackage ./package.nix {
+  inherit flake;
+}

--- a/packages/sidecar/package.nix
+++ b/packages/sidecar/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  flake,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+}:
+
+buildGoModule rec {
+  pname = "sidecar";
+  version = "0.78.0";
+
+  src = fetchFromGitHub {
+    owner = "marcus";
+    repo = "sidecar";
+    rev = "v${version}";
+    hash = "sha256-dVRSd8svfuv1+fYbHpFtXYHXvbAqomXKu9qi6Y5Y5S4=";
+  };
+
+  vendorHash = "sha256-WIhE4CNbxmXaCczLOpFmAkxFcM37iE2tFuUmRnKRN54=";
+
+  subPackages = [ "cmd/sidecar" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X=main.Version=${version}"
+  ];
+
+  doCheck = false;
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.category = "Workflow & Project Management";
+
+  meta = with lib; {
+    description = "Terminal-based development companion for AI coding agents";
+    homepage = "https://github.com/marcus/sidecar";
+    changelog = "https://github.com/marcus/sidecar/releases/tag/v${version}";
+    license = licenses.mit;
+    sourceProvenance = with sourceTypes; [ fromSource ];
+    maintainers = with flake.lib.maintainers; [ afterthought ];
+    mainProgram = "sidecar";
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}


### PR DESCRIPTION
## Summary
- Add [Sidecar](https://github.com/marcus/sidecar) v0.78.0 — a terminal-based development companion (TUI) for monitoring AI coding agents, reviewing diffs, staging commits, and managing tasks
- Built from source with `buildGoModule`
- Category: Workflow & Project Management

## Test plan
- [x] `nix build .#sidecar` succeeds
- [x] `./result/bin/sidecar --version` reports `sidecar version 0.78.0`
- [x] `nix fmt` passes with no changes
- [x] Version check hook enabled

```
$ ./result/bin/sidecar --version
sidecar version 0.78.0
```