### PR TITLE
docs: Add agent-images to README "See Also"

### DIFF
--- a/README.md
+++ b/README.md
@@ -917,6 +917,7 @@ Contributions are welcome! Please:
 
 - [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) - Nix packages for MCP (Model Context Protocol) servers
 - [aaddrick/claude-desktop-debian](https://github.com/aaddrick/claude-desktop-debian?tab=readme-ov-file#using-nix-flake-nixos) - Claude Desktop for Linux
+- [nothingnesses/agent-images](https://github.com/nothingnesses/agent-images) - Sandboxed OCI container images for AI coding agents
 
 ## License
 


### PR DESCRIPTION
## Summary

This adds [agent-images](https://github.com/nothingnesses/agent-images) to the README's "See Also" section. It's a tool that makes it convenient to set up sandboxable (using [agent-box](https://github.com/0xferrous/agent-box)) OCI container images containing coding agents exposed by llm-agents.nix.

## Test plan

<!-- How did you test this change? -->

- [ ] `nix build .#<package>` succeeds
- [ ] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
