### PR TITLE
ccusage*: switch runtime from bun to nodejs

### DIFF
--- a/packages/ccusage-amp/package.nix
+++ b/packages/ccusage-amp/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchzip,
-  bun,
+  nodejs,
   versionCheckHook,
   versionCheckHomeHook,
 }:
@@ -16,8 +16,6 @@ stdenv.mkDerivation rec {
     hash = "sha256-efahFS9R9p3HTkONoI47YnawQc8lZSGMEdrPK8+UqDQ=";
   };
 
-  nativeBuildInputs = [ bun ];
-
   installPhase = ''
     runHook preInstall
 
@@ -29,7 +27,7 @@ stdenv.mkDerivation rec {
     mv $out/bin/index.js $out/bin/ccusage-amp
 
     substituteInPlace $out/bin/ccusage-amp \
-      --replace-fail "#!/usr/bin/env node" "#!${bun}/bin/bun"
+      --replace-fail "#!/usr/bin/env node" "#!${nodejs}/bin/node"
 
     runHook postInstall
   '';

--- a/packages/ccusage-codex/package.nix
+++ b/packages/ccusage-codex/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchzip,
-  bun,
+  nodejs,
   versionCheckHook,
   versionCheckHomeHook,
 }:
@@ -16,8 +16,6 @@ stdenv.mkDerivation rec {
     hash = "sha256-QaYI2qICf5vvyGwxc1tLyzltMfe6fmB+p5n5LPm2R68=";
   };
 
-  nativeBuildInputs = [ bun ];
-
   installPhase = ''
     runHook preInstall
 
@@ -29,7 +27,7 @@ stdenv.mkDerivation rec {
     mv $out/bin/index.js $out/bin/ccusage-codex
 
     substituteInPlace $out/bin/ccusage-codex \
-      --replace-fail "#!/usr/bin/env node" "#!${bun}/bin/bun"
+      --replace-fail "#!/usr/bin/env node" "#!${nodejs}/bin/node"
 
     runHook postInstall
   '';

--- a/packages/ccusage-opencode/package.nix
+++ b/packages/ccusage-opencode/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchzip,
-  bun,
+  nodejs,
   versionCheckHook,
   versionCheckHomeHook,
 }:
@@ -16,8 +16,6 @@ stdenv.mkDerivation rec {
     hash = "sha256-qSrWyL/kCn9tslk4qsUCmIwmQUIemslNY2lwZqcGB8Q=";
   };
 
-  nativeBuildInputs = [ bun ];
-
   installPhase = ''
     runHook preInstall
 
@@ -29,7 +27,7 @@ stdenv.mkDerivation rec {
     mv $out/bin/index.js $out/bin/ccusage-opencode
 
     substituteInPlace $out/bin/ccusage-opencode \
-      --replace-fail "#!/usr/bin/env node" "#!${bun}/bin/bun"
+      --replace-fail "#!/usr/bin/env node" "#!${nodejs}/bin/node"
 
     runHook postInstall
   '';

--- a/packages/ccusage-pi/package.nix
+++ b/packages/ccusage-pi/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchzip,
-  bun,
+  nodejs,
   versionCheckHook,
   versionCheckHomeHook,
 }:
@@ -16,8 +16,6 @@ stdenv.mkDerivation rec {
     hash = "sha256-vuMbXVpMzF4S48oJgoi8ue2Zc+ChyyiUXpY/FNQOQ2E=";
   };
 
-  nativeBuildInputs = [ bun ];
-
   installPhase = ''
     runHook preInstall
 
@@ -29,7 +27,7 @@ stdenv.mkDerivation rec {
     mv $out/bin/index.js $out/bin/ccusage-pi
 
     substituteInPlace $out/bin/ccusage-pi \
-      --replace-fail "#!/usr/bin/env node" "#!${bun}/bin/bun"
+      --replace-fail "#!/usr/bin/env node" "#!${nodejs}/bin/node"
 
     runHook postInstall
   '';

--- a/packages/ccusage/package.nix
+++ b/packages/ccusage/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchzip,
-  bun,
+  nodejs,
   versionCheckHook,
   versionCheckHomeHook,
 }:
@@ -16,8 +16,6 @@ stdenv.mkDerivation rec {
     hash = "sha256-pgXKlQuAvvhJHrOSs9VTF+BMOufPWzV9dheLnvAq2PQ=";
   };
 
-  nativeBuildInputs = [ bun ];
-
   installPhase = ''
     runHook preInstall
 
@@ -29,7 +27,7 @@ stdenv.mkDerivation rec {
     mv $out/bin/index.js $out/bin/ccusage
 
     substituteInPlace $out/bin/ccusage \
-      --replace-fail "#!/usr/bin/env node" "#!${bun}/bin/bun"
+      --replace-fail "#!/usr/bin/env node" "#!${nodejs}/bin/node"
 
     runHook postInstall
   '';


### PR DESCRIPTION
Bun 1.3.10 requires AVX2 (Haswell+, 2013), causing SIGILL crashes on older CPUs like Ivy Bridge. The ccusage packages are pre-bundled JS from npm with no Bun-specific APIs, so Node.js works as a drop-in replacement with broader CPU compatibility.

Fixes: numtide/llm-agents.nix#3319

## Summary

<!-- Briefly describe what this PR does -->

## Test plan

<!-- How did you test this change? -->

- [ ] `nix build .#<package>` succeeds
- [ ] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
