### PR TITLE
beads-rust: 0.1.28 -> 0.1.31

### DIFF
--- a/packages/beads-rust/hashes.json
+++ b/packages/beads-rust/hashes.json
@@ -1,9 +1,13 @@
 {
-  "version": "0.1.28",
-  "hash": "sha256-X7D5OHCLwHPUdfUjSPzAIP/ufsO+yHX3qrgyZqy1UQM=",
-  "cargoHash": "sha256-AR+gYP+yEv0k7MGzdo6CtEeriMflzU4kFxhEuK4hcN0=",
+  "version": "0.1.31",
+  "hash": "sha256-2q4K+2GnFSvJ2YYqe1YeaidNmzWRe3hu2x/qPOG58Cg=",
+  "cargoHash": "sha256-DhL9OJeAoTKbO4xIhgHll/hHff28JwrwIX20OyUJUZo=",
   "frankensqlite": {
-    "rev": "4c58ce050141ae5cb7dee4010446f532ca292224",
-    "hash": "sha256-pEOOOqIXcKxCMW2yc2ksQEbzY2hXvi1jF73YSIQawYM="
+    "rev": "30756a48b9d75439c071fe91e13290388b21d0ed",
+    "hash": "sha256-2eJSXXaH0JC+iBXWAPVtziCqyCnRC12E5cq6nvlO+04="
+  },
+  "asupersync": {
+    "rev": "a87e32adf712600eff8ed8e57fc295a9145692a5",
+    "hash": "sha256-85yHNM4pwFICr9CcxZ7345z0o44rDJvb6T2BfYfeO1g="
   }
 }

--- a/packages/beads-rust/package.nix
+++ b/packages/beads-rust/package.nix
@@ -8,6 +8,23 @@
 
 let
   data = builtins.fromJSON (builtins.readFile ./hashes.json);
+
+  # Upstream uses [patch.crates-io] with local path deps pointing at sibling
+  # checkouts of frankensqlite and asupersync.  Fetch them separately and place
+  # them where Cargo expects.
+  # https://github.com/Dicklesworthstone/beads_rust/issues/183
+  frankensqlite = fetchFromGitHub {
+    owner = "Dicklesworthstone";
+    repo = "frankensqlite";
+    inherit (data.frankensqlite) rev hash;
+  };
+
+  # frankensqlite workspace depends on asupersync via path = "../asupersync"
+  asupersync = fetchFromGitHub {
+    owner = "Dicklesworthstone";
+    repo = "asupersync";
+    inherit (data.asupersync) rev hash;
+  };
 in
 rustPlatform.buildRustPackage {
   pname = "beads-rust";
@@ -20,18 +37,11 @@ rustPlatform.buildRustPackage {
     inherit (data) hash;
   };
 
-  # Upstream uses [patch.crates-io] with local path deps pointing at a sibling
-  # frankensqlite checkout.  Fetch it separately and place it where Cargo expects.
-  # https://github.com/Dicklesworthstone/beads_rust/issues/183
-  frankensqlite = fetchFromGitHub {
-    owner = "Dicklesworthstone";
-    repo = "frankensqlite";
-    inherit (data.frankensqlite) rev hash;
-  };
-
   postUnpack = ''
-    cp -r $frankensqlite frankensqlite
+    cp -r ${frankensqlite} frankensqlite
     chmod -R u+w frankensqlite
+    cp -r ${asupersync} asupersync
+    chmod -R u+w asupersync
   '';
 
   # fsqlite uses #![feature(peer_credentials_unix_socket)] which requires nightly.

--- a/packages/beads-rust/update.py
+++ b/packages/beads-rust/update.py
@@ -3,9 +3,9 @@
 
 """Update script for beads-rust package.
 
-Upstream uses [patch.crates-io] with local path deps to a sibling
-frankensqlite repo.  This script updates both beads_rust and the
-matching frankensqlite commit in hashes.json, then recalculates
+Upstream uses [patch.crates-io] with local path deps to sibling
+frankensqlite and asupersync repos.  This script updates beads_rust
+and the matching sibling commits in hashes.json, then recalculates
 cargoHash via a dummy-hash build.
 """
 
@@ -28,6 +28,7 @@ HASHES_FILE = Path(__file__).parent / "hashes.json"
 OWNER = "Dicklesworthstone"
 BEADS_REPO = "beads_rust"
 FRANK_REPO = "frankensqlite"
+ASYNC_REPO = "asupersync"
 
 
 def get_release_date(owner: str, repo: str, version: str) -> str:
@@ -40,15 +41,14 @@ def get_release_date(owner: str, repo: str, version: str) -> str:
     return str(data["created_at"])
 
 
-def get_frankensqlite_rev(until: str) -> str:
-    """Get the latest frankensqlite commit at or before a given date."""
+def get_sibling_rev(repo: str, until: str) -> str:
+    """Get the latest commit of a sibling repo at or before a given date."""
     url = (
-        f"https://api.github.com/repos/{OWNER}/{FRANK_REPO}"
-        f"/commits?until={until}&per_page=1"
+        f"https://api.github.com/repos/{OWNER}/{repo}/commits?until={until}&per_page=1"
     )
     data = fetch_json(url)
     if not isinstance(data, list) or len(data) == 0:
-        msg = "No frankensqlite commits found"
+        msg = f"No {repo} commits found"
         raise ValueError(msg)
     return str(data[0]["sha"])
 
@@ -77,15 +77,17 @@ def main() -> None:
     data["version"] = latest
     data["hash"] = src_hash
 
-    # Update frankensqlite to the commit matching the release
-    print(f"Finding frankensqlite commit matching v{latest} release...")
+    # Update sibling repos to commits matching the release date
     release_date = get_release_date(OWNER, BEADS_REPO, latest)
-    frank_rev = get_frankensqlite_rev(release_date)
-    print(f"frankensqlite rev: {frank_rev}")
 
-    print("Prefetching frankensqlite...")
-    frank_hash = prefetch_github(OWNER, FRANK_REPO, frank_rev)
-    data["frankensqlite"] = {"rev": frank_rev, "hash": frank_hash}
+    for name, repo in [("frankensqlite", FRANK_REPO), ("asupersync", ASYNC_REPO)]:
+        print(f"Finding {name} commit matching v{latest} release...")
+        rev = get_sibling_rev(repo, release_date)
+        print(f"{name} rev: {rev}")
+
+        print(f"Prefetching {name}...")
+        h = prefetch_github(OWNER, repo, rev)
+        data[name] = {"rev": rev, "hash": h}
 
     # Recalculate cargoHash via dummy-hash build
     cargo_hash = calculate_dependency_hash(
@@ -94,7 +96,7 @@ def main() -> None:
     data["cargoHash"] = cargo_hash
 
     save_hashes(HASHES_FILE, data)
-    print(f"Updated beads-rust to {latest} with frankensqlite {frank_rev[:12]}")
+    print(f"Updated beads-rust to {latest}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Move frankensqlite fetchFromGitHub into the let binding and use Nix string interpolation (${frankensqlite}) instead of a shell variable ($frankensqlite). The old approach set frankensqlite as a top-level derivation attribute, but buildRustPackage does not propagate arbitrary attributes into the vendor-staging derivation, so $frankensqlite was empty there and the cp failed.

## Summary

<!-- Briefly describe what this PR does -->

## Test plan

<!-- How did you test this change? -->

- [ ] `nix build .#<package>` succeeds
- [ ] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
