### PR TITLE
codex-acp: fix vendor path for newer cargo

### DIFF
--- a/packages/codex-acp/package.nix
+++ b/packages/codex-acp/package.nix
@@ -53,9 +53,16 @@ rustPlatform.buildRustPackage {
 
   inherit cargoHash;
 
-  # Place node-version.txt at the vendor dir root where the include_str! resolves to
+  # Place node-version.txt where include_str!("../../../../node-version.txt") in
+  # codex-core's src/tools/js_repl/mod.rs resolves to.  Newer cargo (≥1.84)
+  # groups git-sourced crates under source-git-N/ subdirectories in the vendor
+  # dir, adding one extra path component; older cargo placed them directly in
+  # the vendor root.  Copy to both locations so the build works with either.
   preBuild = ''
     cp ${nodeVersionFile} "$NIX_BUILD_TOP/codex-acp-${version}-vendor/node-version.txt"
+    for d in "$NIX_BUILD_TOP/codex-acp-${version}-vendor"/source-git-*/; do
+      [ -d "$d" ] && cp ${nodeVersionFile} "$d/node-version.txt"
+    done
   '';
 
   env = lib.optionalAttrs stdenv.hostPlatform.isLinux {


### PR DESCRIPTION
Newer cargo (≥1.84) groups git-sourced crates under `source-git-N/` subdirectories in the vendor dir. The `include_str!` for `node-version.txt` in codex-core's `src/tools/js_repl/mod.rs` resolves one level deeper, so the file we place in the vendor dir is no longer found.

Fix by copying `node-version.txt` into both the vendor root and any `source-git-*/` directories, so the build works with both old and new cargo vendoring layouts.

This fixes the `codex-acp` build failure seen in #3396 (nixpkgs update).