### PR TITLE
picoclaw: fix retag + drop redundant go override

### DIFF
--- a/packages/picoclaw/package.nix
+++ b/packages/picoclaw/package.nix
@@ -3,13 +3,12 @@
   flake,
   buildGoModule,
   fetchFromGitHub,
-  go_1_25,
   unpinGoModVersionHook,
   versionCheckHook,
   versionCheckHomeHook,
 }:
 
-buildGoModule.override { go = go_1_25; } rec {
+buildGoModule rec {
   pname = "picoclaw";
   version = "0.2.3";
 


### PR DESCRIPTION
### `c4e6c312` picoclaw: update hashes after upstream retagged v0.2.3
Upstream force-pushed the v0.2.3 tag — builds from a cold store currently fail with a fixed-output hash mismatch. Re-pinned source + vendorHash.

### `a06d3001` picoclaw: drop redundant go_1_25 override
`go.mod` declares `go 1.25.7` == nixpkgs default, so the override is a no-op. Also verified builds with `go_1_26`, so this stays green when nixpkgs promotes 1.26.

```
🦞 picoclaw 0.2.3
  Go: go1.25.7
Finished versionCheckPhase
```