### PR TITLE
onnxruntime: work around -Werror=unused-result on Darwin

### DIFF
--- a/lib/onnxruntime-override.nix
+++ b/lib/onnxruntime-override.nix
@@ -1,0 +1,33 @@
+# Workaround for https://github.com/numtide/llm-agents.nix/issues/3409
+# Removal tracked in https://github.com/numtide/llm-agents.nix/issues/3451
+#
+# onnxruntime 1.23.2 fails on Darwin with -Werror,-Wunused-result because
+# protobuf 34 added [[nodiscard]] to SerializeToString. The nixpkgs
+# protobuf34-nodiscard.patch is incomplete for 1.23.2 (misses the test
+# suite). Fixed upstream by NixOS/nixpkgs#501901 (onnxruntime 1.24.4)
+# but that has not reached nixpkgs-unstable yet.
+#
+# Rather than backporting the version bump, suppress the warning. This
+# override becomes a no-op once nixpkgs-unstable advances and can be
+# removed at that point — see issue #3451 for the cleanup checklist.
+#
+# The override is Darwin-only: applying it on Linux would force a rebuild
+# from source instead of substituting from cache.nixos.org, and the test
+# suite (QDQTransformerTests/NhwcTransformerTests) fails on builders that
+# lack AVX-VNNI.
+{
+  lib,
+  stdenv,
+  onnxruntime,
+}:
+if lib.versionAtLeast onnxruntime.version "1.24" || !stdenv.hostPlatform.isDarwin then
+  onnxruntime
+else
+  onnxruntime.overrideAttrs (old: {
+    env = (old.env or { }) // {
+      NIX_CFLAGS_COMPILE = toString [
+        (old.env.NIX_CFLAGS_COMPILE or "")
+        "-Wno-error=unused-result"
+      ];
+    };
+  })

--- a/packages/ck/default.nix
+++ b/packages/ck/default.nix
@@ -2,4 +2,6 @@
   pkgs,
   ...
 }:
-pkgs.callPackage ./package.nix { }
+pkgs.callPackage ./package.nix {
+  onnxruntime = pkgs.callPackage ../../lib/onnxruntime-override.nix { };
+}

--- a/packages/hermes-agent/default.nix
+++ b/packages/hermes-agent/default.nix
@@ -4,7 +4,16 @@
   flake,
   ...
 }:
+let
+  onnxruntime' = pkgs.callPackage ../../lib/onnxruntime-override.nix { };
+  python3' = pkgs.python3.override {
+    packageOverrides = _final: prev: {
+      onnxruntime = prev.onnxruntime.override { onnxruntime = onnxruntime'; };
+    };
+  };
+in
 pkgs.callPackage ./package.nix {
   inherit flake;
   inherit (perSystem.self) versionCheckHomeHook;
+  python3 = python3';
 }


### PR DESCRIPTION
onnxruntime 1.23.2 fails on Darwin because protobuf 34 added `[[nodiscard]]` to `SerializeToString` and the nixpkgs `protobuf34-nodiscard.patch` is incomplete for the test suite. Clang treats the discarded returns as errors via `-Werror`.

Fixed upstream in NixOS/nixpkgs#501901 (onnxruntime 1.24.4) but not yet in nixpkgs-unstable.

**Approach**: inject `-Wno-error=unused-result` via `NIX_CFLAGS_COMPILE`, version-gated so it becomes a no-op once nixpkgs ships ≥1.24. Applied to:
- `ck` (direct onnxruntime consumer)
- `hermes-agent` (transitive via `faster-whisper`)

```nix
# lib/onnxruntime-override.nix
if lib.versionAtLeast onnxruntime.version "1.24" then
  onnxruntime  # no-op once nixpkgs catches up
else
  onnxruntime.overrideAttrs (…NIX_CFLAGS_COMPILE += -Wno-error=unused-result…)
```

Fixes #3409. Unblocks #3396 (partially — `arrow-cpp` broken on x86_64-darwin is a separate issue).