### PR TITLE
gitagent: init at 0.1.7

### DIFF
--- a/packages/gitagent/default.nix
+++ b/packages/gitagent/default.nix
@@ -1,0 +1,8 @@
+{ pkgs, flake, ... }:
+let
+  npmPackumentSupport = pkgs.callPackage ../../lib/fetch-npm-deps.nix { };
+in
+pkgs.callPackage ./package.nix {
+  inherit flake;
+  inherit (npmPackumentSupport) fetchNpmDepsWithPackuments npmConfigHook;
+}

--- a/packages/gitagent/package.nix
+++ b/packages/gitagent/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  flake,
+  fetchNpmDepsWithPackuments,
+  npmConfigHook,
+}:
+
+buildNpmPackage (finalAttrs: {
+  inherit npmConfigHook;
+  pname = "gitagent";
+  version = "0.1.7";
+
+  src = fetchFromGitHub {
+    owner = "open-gitagent";
+    repo = "gitagent";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-gL6mq6DR95O6dnrylizDd+BhHiVgHXHtoqJ09hxe0Tc=";
+  };
+
+  npmDeps = fetchNpmDepsWithPackuments {
+    inherit (finalAttrs) src;
+    name = "${finalAttrs.pname}-${finalAttrs.version}-npm-deps";
+    hash = "sha256-kpN9qoAt6LWYshK9ERILpqGSRAVsqY1kiJCw48loFp0=";
+    fetcherVersion = 2;
+  };
+  makeCacheWritable = true;
+
+  passthru.category = "Utilities";
+
+  meta = {
+    description = "Framework-agnostic, git-native standard for defining AI agents";
+    homepage = "https://github.com/open-gitagent/gitagent";
+    changelog = "https://github.com/open-gitagent/gitagent/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    maintainers = with flake.lib.maintainers; [ mulatta ];
+    mainProgram = "gitagent";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
## Summary

init gitagent. A framework-agnostic, git-native standard for defining AI agents 

## Test plan

regression test for version update was tested
<!-- How did you test this change? -->

- [x] `nix build .#<package>` succeeds
- [x] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
