### PR TITLE
omp: add zlib as runtime dependency for dlopen

### DIFF
--- a/packages/omp/package.nix
+++ b/packages/omp/package.nix
@@ -5,6 +5,7 @@
   makeWrapper,
   autoPatchelfHook,
   stdenv,
+  zlib,
 }:
 
 let
@@ -42,6 +43,10 @@ stdenvNoCC.mkDerivation {
 
   buildInputs = lib.optionals stdenvNoCC.hostPlatform.isLinux [
     stdenv.cc.cc.lib
+  ];
+
+  runtimeDependencies = lib.optionals stdenvNoCC.hostPlatform.isLinux [
+    zlib
   ];
 
   installPhase = ''


### PR DESCRIPTION
The omp binary `dlopen`s `libz.so.1` at runtime (via bun's `node:zlib`), but zlib was not available. This adds `zlib` to `runtimeDependencies` so `autoPatchelfHook` includes it in the binary's RPATH.

### Changes

- Added `zlib` to function inputs
- Added `zlib` to `runtimeDependencies` (Linux only)

### Verification

```
$ strings .omp-wrapped | grep libz
libz.so.1

$ patchelf --print-rpath $out/bin/.omp-wrapped
/nix/store/...-zlib-1.3.2/lib
```