### PR TITLE
parallel-cli: init at 0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -733,6 +733,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>parallel-cli</strong> - AI-powered web search, extraction, and research CLI from Parallel</summary>
+
+- **Source**: source
+- **License**: MIT
+- **Homepage**: https://github.com/parallel-web/parallel-web-tools
+- **Usage**: `nix run github:numtide/llm-agents.nix#parallel-cli -- --help`
+- **Nix**: [packages/parallel-cli/package.nix](packages/parallel-cli/package.nix)
+
+</details>
+<details>
 <summary><strong>qmd</strong> - mini cli search engine for your docs, knowledge bases, meeting notes, whatever. Tracking current sota approaches while being all local</summary>
 
 - **Source**: source

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -67,6 +67,11 @@ inputs.nixpkgs.lib.extend (
         githubId = 8287771;
         name = "Aliez Ren";
       };
+      SecBear = {
+        github = "SecBear";
+        githubId = 253731654;
+        name = "Bryce Thorpe";
+      };
     };
   }
 )

--- a/packages/parallel-cli/default.nix
+++ b/packages/parallel-cli/default.nix
@@ -1,0 +1,10 @@
+{
+  pkgs,
+  flake,
+  perSystem,
+  ...
+}:
+pkgs.callPackage ./package.nix {
+  inherit flake;
+  inherit (perSystem.self) versionCheckHomeHook;
+}

--- a/packages/parallel-cli/hashes.json
+++ b/packages/parallel-cli/hashes.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.2.0",
+  "hash": "sha256-wau6A6YB0VawODsEvgZPQufYfOpzyr96Rh2FcmoBUFc=",
+  "parallelWeb": {
+    "version": "0.4.2",
+    "hash": "sha256-JlxccLfmwlpsG9l5OjDii5cT3l1BteSQ1w1OhftoBgg="
+  },
+  "sqlalchemyBigquery": {
+    "version": "1.16.0",
+    "hash": "sha256-5VfghxRnOTimWDdK6fe0RpbQNG6lnH5ynRnIr2Ze118="
+  }
+}

--- a/packages/parallel-cli/package.nix
+++ b/packages/parallel-cli/package.nix
@@ -1,0 +1,166 @@
+{
+  lib,
+  flake,
+  python3,
+  fetchFromGitHub,
+  versionCheckHook,
+  versionCheckHomeHook,
+}:
+
+let
+  versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
+  inherit (versionData) version hash;
+
+  parallelWebData = versionData.parallelWeb;
+  sqlalchemyBigqueryData = versionData.sqlalchemyBigquery;
+
+  parallel-web = python3.pkgs.buildPythonPackage rec {
+    pname = "parallel-web";
+    version = parallelWebData.version;
+    pyproject = true;
+
+    src = fetchFromGitHub {
+      owner = "parallel-web";
+      repo = "parallel-sdk-python";
+      rev = "v${version}";
+      hash = parallelWebData.hash;
+    };
+
+    build-system = with python3.pkgs; [
+      hatchling
+      hatch-fancy-pypi-readme
+    ];
+
+    # Upstream pins build-system dependencies more tightly than nixpkgs does.
+    pypaBuildFlags = [ "--skip-dependency-check" ];
+
+    dependencies = with python3.pkgs; [
+      anyio
+      distro
+      httpx
+      pydantic
+      sniffio
+      typing-extensions
+    ];
+
+    pythonImportsCheck = [ "parallel" ];
+
+    meta = with lib; {
+      description = "The official Python library for the Parallel API";
+      homepage = "https://github.com/parallel-web/parallel-sdk-python";
+      license = licenses.mit;
+      sourceProvenance = with sourceTypes; [ fromSource ];
+      platforms = platforms.all;
+    };
+  };
+
+  sqlalchemy-bigquery = python3.pkgs.buildPythonPackage rec {
+    pname = "sqlalchemy-bigquery";
+    version = sqlalchemyBigqueryData.version;
+    pyproject = true;
+
+    src = fetchFromGitHub {
+      owner = "googleapis";
+      repo = "python-bigquery-sqlalchemy";
+      rev = "v${version}";
+      hash = sqlalchemyBigqueryData.hash;
+    };
+
+    build-system = with python3.pkgs; [ setuptools ];
+
+    dependencies = with python3.pkgs; [
+      google-api-core
+      google-auth
+      google-cloud-bigquery
+      packaging
+      sqlalchemy
+    ];
+
+    pythonImportsCheck = [ "sqlalchemy_bigquery" ];
+
+    meta = with lib; {
+      description = "SQLAlchemy dialect for BigQuery";
+      homepage = "https://github.com/googleapis/python-bigquery-sqlalchemy";
+      license = licenses.mit;
+      sourceProvenance = with sourceTypes; [ fromSource ];
+      platforms = platforms.all;
+    };
+  };
+
+  # packages/parallel-cli/update.py keeps these sidecar-managed embedded pins
+  # aligned with the minimum versions required by upstream. Embedded pins
+  # advance only when upstream raises its declared minimum; they never chase
+  # the latest release independently.
+
+  # The nixpkgs Snowflake connector package is source-built from GitHub already,
+  # but its upstream test suite exercises local socket/network behavior that is
+  # not reliable in our build sandbox. Keep the package and disable checks here
+  # instead of dropping Snowflake support from the CLI surface.
+  snowflake-connector-python = python3.pkgs.snowflake-connector-python.overridePythonAttrs (_old: {
+    doCheck = false;
+  });
+in
+python3.pkgs.buildPythonApplication rec {
+  pname = "parallel-cli";
+  inherit version;
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "parallel-web";
+    repo = "parallel-web-tools";
+    rev = "v${version}";
+    inherit hash;
+  };
+
+  build-system = with python3.pkgs; [ hatchling ];
+
+  # Package the source CLI with the dependency set needed for the full upstream
+  # [all] extra: cli, polars, duckdb, snowflake, bigquery. Spark is dev-only.
+  dependencies = with python3.pkgs; [
+    parallel-web
+    sqlalchemy-bigquery
+    snowflake-connector-python
+    click
+    duckdb
+    httpx
+    nest-asyncio
+    polars
+    pyarrow
+    pyyaml
+    python-dotenv
+    questionary
+    rich
+    sqlalchemy
+  ];
+
+  pythonImportsCheck = [
+    "parallel_web_tools"
+    "parallel_web_tools.integrations.snowflake"
+    "snowflake.connector"
+    "sqlalchemy_bigquery"
+  ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    versionCheckHomeHook
+  ];
+  versionCheckProgramArg = [ "--version" ];
+
+  passthru.category = "Utilities";
+
+  meta = with lib; {
+    description = "AI-powered web search, extraction, and research CLI from Parallel";
+    homepage = "https://github.com/parallel-web/parallel-web-tools";
+    changelog = "https://github.com/parallel-web/parallel-web-tools/releases/tag/v${version}";
+    license = licenses.mit;
+    sourceProvenance = with sourceTypes; [ fromSource ];
+    maintainers = with flake.lib.maintainers; [ SecBear ];
+    mainProgram = "parallel-cli";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "aarch64-darwin"
+    ];
+  };
+}

--- a/packages/parallel-cli/update.py
+++ b/packages/parallel-cli/update.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env nix
+#! nix shell --inputs-from .# nixpkgs#python3 --command python3
+
+"""Update script for parallel-cli and its vendored Python dependencies."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+
+from updater import (
+    calculate_url_hash,
+    fetch_github_latest_release,
+    load_hashes,
+    save_hashes,
+    should_update,
+)
+
+HASHES_FILE = Path(__file__).parent / "hashes.json"
+
+# Each tuple: hashes.json key (None = top-level), GitHub owner, GitHub repo.
+PACKAGES = [
+    (None, "parallel-web", "parallel-web-tools"),
+    ("parallelWeb", "parallel-web", "parallel-sdk-python"),
+    ("sqlalchemyBigquery", "googleapis", "python-bigquery-sqlalchemy"),
+]
+
+
+def github_hash(owner: str, repo: str, version: str) -> str:
+    """Prefetch the GitHub v-tagged release tarball hash."""
+    url = f"https://github.com/{owner}/{repo}/archive/refs/tags/v{version}.tar.gz"
+    return calculate_url_hash(url, unpack=True)
+
+
+def main() -> None:
+    """Update parallel-cli and vendored dependencies to latest releases."""
+    data = load_hashes(HASHES_FILE)
+    changed = False
+
+    for key, owner, repo in PACKAGES:
+        entry = data if key is None else data[key]
+        current = entry["version"]
+        latest = fetch_github_latest_release(owner, repo)
+        print(f"{repo}: current={current}, latest={latest}")
+
+        if should_update(current, latest):
+            entry["version"] = latest
+            entry["hash"] = github_hash(owner, repo, latest)
+            changed = True
+
+    if not changed:
+        print("Already up to date")
+        return
+
+    save_hashes(HASHES_FILE, data)
+    print(f"Updated parallel-cli to {data['version']}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds [`parallel-cli`](https://github.com/parallel-web/parallel-web-tools), a source-built CLI for AI-powered web search, extraction, entity discovery, and deep research from [Parallel](https://parallel.ai). This is a search/data-enrichment tool, comparable to exa.

## What this includes

- `packages/parallel-cli/package.nix` — `buildPythonApplication` wrapping `parallel-web-tools` with all deps from the upstream `[all]` extra (cli, polars, duckdb, snowflake, bigquery)
- `packages/parallel-cli/hashes.json` — pinned hashes for the top-level source plus two embedded subordinate packages not in nixpkgs
- `packages/parallel-cli/update.py` — custom updater using `scripts/updater/`; `nix-update` cannot handle this package because it has three independent GitHub sources with coordinated version pins
- `packages/parallel-cli/default.nix` — blueprint wrapper
- `lib/default.nix` — adds `SecBear` as maintainer

## Dependency design

Two packages are embedded as private `buildPythonPackage` let-bindings (not in nixpkgs):

- **`parallel-web`** (`parallel-web/parallel-sdk-python`) — the official Parallel Python SDK, pinned at the minimum version declared by upstream, advanced only when upstream raises its floor
- **`sqlalchemy-bigquery`** (`googleapis/python-bigquery-sqlalchemy`) — same pinning policy

**`snowflake-connector-python`** is taken from nixpkgs with `doCheck = false`. Its upstream test suite exercises local socket/network behaviour not reliable in the Nix build sandbox.

**Dependency scope:** deps match the upstream `[all]` extra exactly (`cli + polars + duckdb + snowflake + bigquery`). `pyspark` and `pandas` are intentionally excluded — they are `[spark]`/`[dev]`-only extras, not part of the documented full CLI feature set.

## Platforms

`x86_64-darwin` is excluded: `pyarrow` depends on `arrow-cpp` which is marked broken in nixpkgs on that platform.

## Known constraints

- `polars` in nixpkgs-unstable is 1.36.1; upstream declares `>=1.37.0`. The package builds and all import checks pass (Nix does not enforce pip version constraints; the integrations module uses lazy loading). Will resolve automatically when nixpkgs updates polars.
- Upstream repo has no standalone `LICENSE` file; MIT is declared in `pyproject.toml` and classifiers.

## Testing

```
# macOS (aarch64-darwin)
nix build --accept-flake-config .#parallel-cli
nix build --accept-flake-config .#checks.aarch64-darwin.pkgs-parallel-cli
result/bin/parallel-cli --version  # parallel-cli, version 0.2.0

# Linux (x86_64-linux)
nix build --accept-flake-config .#parallel-cli
nix build --accept-flake-config .#checks.x86_64-linux.pkgs-parallel-cli
result/bin/parallel-cli --version  # parallel-cli, version 0.2.0

nix fmt  # 0 changed files
```