### PR TITLE
omp: use LD_LIBRARY_PATH for zlib instead of runtimeDependencies

### DIFF
--- a/packages/omp/package.nix
+++ b/packages/omp/package.nix
@@ -45,10 +45,6 @@ stdenvNoCC.mkDerivation {
     stdenv.cc.cc.lib
   ];
 
-  runtimeDependencies = lib.optionals stdenvNoCC.hostPlatform.isLinux [
-    zlib
-  ];
-
   installPhase = ''
     runHook preInstall
 
@@ -57,7 +53,13 @@ stdenvNoCC.mkDerivation {
     chmod +x $out/bin/omp
 
     wrapProgram $out/bin/omp \
-      --set PI_SKIP_VERSION_CHECK 1
+      --set PI_SKIP_VERSION_CHECK 1 \
+      ${lib.optionalString stdenvNoCC.hostPlatform.isLinux "--prefix LD_LIBRARY_PATH : ${
+        lib.makeLibraryPath [
+          zlib
+          stdenv.cc.cc.lib
+        ]
+      }"}
 
     runHook postInstall
   '';


### PR DESCRIPTION
## Problem

The previous fix ([runtimeDependencies for zlib](https://github.com/numtide/llm-agents.nix/commit/6a1723a6)) patches the RUNPATH of the main omp binary via `autoPatchelfHook`, but the native addon (`pi_natives.linux-x64-modern.node`) is extracted at **runtime** to `~/.omp/natives/`. Since `autoPatchelfHook` never sees this file, it has no RUNPATH and still can't find `libz.so.1`:

```
[Uncaught Exception] Error: Failed to load pi_natives native addon for linux-x64 (modern).
  .../pi_natives.linux-x64-modern.node: libz.so.1: cannot open shared object file: No such file or directory
```

## Fix

Replace `runtimeDependencies` (which only affects build-time ELF binaries) with `--prefix LD_LIBRARY_PATH` in the wrapper script, so runtime-extracted `.node` addons inherit the library path.

## Verification

Tested locally on NixOS x86_64-linux — confirmed the old package fails on `omp --help` and the patched package works correctly.