### PR TITLE
fix(gno): include vendor/ dir with fts5-snowball native extension

### DIFF
--- a/packages/gno/package.nix
+++ b/packages/gno/package.nix
@@ -167,7 +167,7 @@ stdenv.mkDerivation {
 
       mkdir -p $out/lib/gno $out/bin
 
-      cp -r node_modules src package.json $out/lib/gno/
+      cp -r node_modules src vendor package.json $out/lib/gno/
 
       # Patch detectGlibc.js to always return true on Linux
       # node-llama-cpp checks FHS paths (/lib, /usr/lib) for glibc which don't exist on NixOS


### PR DESCRIPTION
## Summary

- Include `vendor/` directory in gno package installPhase
- Fixes `fts5-snowball binary not found for linux-x64` crash on startup

The gno source ships vendored fts5-snowball SQLite extensions at `vendor/fts5-snowball/<platform>/fts5stemmer.{so,dylib}` for FTS5 multilingual stemming. The installPhase was only copying `node_modules src package.json` — missing the `vendor/` directory entirely.

## Test plan

- [ ] `nix build .#gno` succeeds
- [ ] `find $(nix build .#gno --print-out-paths)/lib/gno/vendor -name 'fts5stemmer.*'` shows platform binaries
- [ ] `HOME=$(mktemp -d) gno init --yes && gno serve --port 0` starts without fts5-snowball error

🤖 Generated with [Claude Code](https://claude.com/claude-code)