### PR TITLE
zat: fix license to gpl3Only

### DIFF
--- a/packages/zat/package.nix
+++ b/packages/zat/package.nix
@@ -32,7 +32,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     description = "Code outline viewer for LLM coding agents — shows exported symbols with line numbers";
     homepage = "https://github.com/bglgwyng/zat";
     changelog = "https://github.com/bglgwyng/zat/releases/tag/v${finalAttrs.version}";
-    license = lib.licenses.unfree;
+    license = lib.licenses.gpl3Only;
     sourceProvenance = with lib.sourceTypes; [ fromSource ];
     maintainers = with flake.lib.maintainers; [ mic92 ];
     mainProgram = "zat";


### PR DESCRIPTION
Upstream LICENSE file and GitHub API both report GPL-3.0, but the
package was initialized with unfree. This caused the README regen
workflow (#3613) to flip the docs to unfree.

Ref: https://github.com/bglgwyng/zat/blob/main/LICENSE
