### PR TITLE
[codex] codex-acp: 0.10.0 -> 0.11.1

### DIFF
--- a/packages/codex-acp/hashes.json
+++ b/packages/codex-acp/hashes.json
@@ -1,8 +1,18 @@
 {
-  "version": "0.10.0",
-  "hash": "sha256-pFlQ1ETjSfZ9oDhJ3J6AWgTyfLSPWf6oFJ/UiOTqVU8=",
-  "cargoHash": "sha256-70CHZYLRRQJE42ZqARVl4gUryuUGFwhKBHGCALWdCJ4=",
-  "codexRev": "ab7a5b87a9e455235f65637f1675c03051481c87",
-  "codexSrcHash": "sha256-uhT2jQUKuefLjGl39E2YZ9fRPL/f/TvVldvv/9EKQK8=",
+  "version": "0.11.1",
+  "hash": "sha256-ufKRtfkr+CFaVg84vsE3OAvrYhVW6kQclIW2lfeaj+Y=",
+  "cargoHash": "sha256-RxQN34P7N8Ce8Udmrn8NC/bCVdmxtP0KqheUcwWK9k8=",
+  "codexOwner": "openai",
+  "codexRev": "4c70bff480af37b1bf1a9b352b8341060fe55755",
+  "codexSrcHash": "sha256-Ezd8KaEMVeJPKC74CSPhecPLZghm0v6JkQTCPhr/2nY=",
+  "librusty_v8": {
+    "version": "146.4.0",
+    "hashes": {
+      "x86_64-linux": "sha256-5ktNmeSuKTouhGJEqJuAF4uhA4LBP7WRwfppaPUpEVM=",
+      "aarch64-linux": "sha256-2/FlsHyBvbBUvARrQ9I+afz3vMGkwbW0d2mDpxBi7Ng=",
+      "x86_64-darwin": "sha256-YwzSQPG77NsHFBfcGDh6uBz2fFScHFFaC0/Pnrpke7c=",
+      "aarch64-darwin": "sha256-v+LJvjKlbChUbw+WWCXuaPv2BkBfMQzE4XtEilaM+Yo="
+    }
+  },
   "nodeVersionHash": "sha256-QTcJTneSy0n+Gv3cP4cgjw70rf7306zR3vAZh4bTk8I="
 }

--- a/packages/codex-acp/package.nix
+++ b/packages/codex-acp/package.nix
@@ -14,8 +14,10 @@ let
     version
     hash
     cargoHash
+    codexOwner
     codexRev
     codexSrcHash
+    librusty_v8
     nodeVersionHash
     ;
 
@@ -24,7 +26,7 @@ let
   # Cargo vendoring flattens the workspace structure so this file is missing;
   # we fetch it from the exact commit that Cargo.lock pins.
   nodeVersionFile = fetchurl {
-    url = "https://raw.githubusercontent.com/zed-industries/codex/${codexRev}/codex-rs/node-version.txt";
+    url = "https://raw.githubusercontent.com/${codexOwner}/codex/${codexRev}/codex-rs/node-version.txt";
     hash = nodeVersionHash;
   };
 
@@ -34,10 +36,19 @@ let
   # fetch the codex source at the pinned rev to provide it via
   # CODEX_BWRAP_SOURCE_DIR.
   codexSrc = fetchFromGitHub {
-    owner = "zed-industries";
+    owner = codexOwner;
     repo = "codex";
     rev = codexRev;
     hash = codexSrcHash;
+  };
+
+  # The v8 crate downloads a prebuilt static library at build time. Fetch it
+  # as a fixed-output derivation so the build stays sandboxed.
+  librustyV8 = fetchurl {
+    name = "librusty_v8-${librusty_v8.version}";
+    url = "https://github.com/denoland/rusty_v8/releases/download/v${librusty_v8.version}/librusty_v8_release_${stdenv.hostPlatform.rust.rustcTarget}.a.gz";
+    hash = librusty_v8.hashes.${stdenv.hostPlatform.system};
+    meta.sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
   };
 in
 rustPlatform.buildRustPackage {
@@ -65,7 +76,10 @@ rustPlatform.buildRustPackage {
     done
   '';
 
-  env = lib.optionalAttrs stdenv.hostPlatform.isLinux {
+  env = {
+    RUSTY_V8_ARCHIVE = librustyV8;
+  }
+  // lib.optionalAttrs stdenv.hostPlatform.isLinux {
     # Point the codex-linux-sandbox build.rs at the vendored bubblewrap source
     CODEX_BWRAP_SOURCE_DIR = "${codexSrc}/codex-rs/vendor/bubblewrap";
   };
@@ -92,7 +106,10 @@ rustPlatform.buildRustPackage {
     license = licenses.asl20;
     maintainers = with maintainers; [ ];
     platforms = platforms.unix;
-    sourceProvenance = with sourceTypes; [ fromSource ];
+    sourceProvenance = with sourceTypes; [
+      fromSource
+      binaryNativeCode
+    ];
     mainProgram = "codex-acp";
   };
 }

--- a/packages/codex-acp/update.py
+++ b/packages/codex-acp/update.py
@@ -3,10 +3,10 @@
 
 """Update script for codex-acp package.
 
-codex-acp depends on codex-core from the codex monorepo via a git dependency.
-codex-core's build uses include_str!("../../../../node-version.txt") which
-resolves outside the vendored crate. We need to track the codex git rev from
-Cargo.lock and fetch node-version.txt from the same commit.
+codex-acp depends on codex crates from a git source. codex-core's build uses
+include_str!("../../../../node-version.txt"), which resolves outside the
+vendored crate. We track the pinned codex source from Cargo.lock and fetch
+node-version.txt from the same commit.
 """
 
 import re
@@ -20,6 +20,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
 from updater import (
     calculate_dependency_hash,
+    calculate_platform_hashes,
     calculate_url_hash,
     fetch_github_latest_release,
     load_hashes,
@@ -33,13 +34,16 @@ SCRIPT_DIR = Path(__file__).parent
 HASHES_FILE = SCRIPT_DIR / "hashes.json"
 OWNER = "zed-industries"
 REPO = "codex-acp"
+PLATFORMS = {
+    "x86_64-linux": "x86_64-unknown-linux-gnu",
+    "aarch64-linux": "aarch64-unknown-linux-gnu",
+    "x86_64-darwin": "x86_64-apple-darwin",
+    "aarch64-darwin": "aarch64-apple-darwin",
+}
 
 
-def extract_codex_rev_from_tarball(tag: str) -> str:
-    """Download the release tarball and extract the codex git rev from Cargo.lock.
-
-    The Cargo.lock pins codex crates to a specific commit on the 'acp' branch.
-    """
+def extract_release_pins_from_tarball(tag: str) -> tuple[str, str, str]:
+    """Download the release tarball and extract pinned versions from Cargo.lock."""
     url = f"https://github.com/{OWNER}/{REPO}/archive/refs/tags/{tag}.tar.gz"
 
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -54,14 +58,39 @@ def extract_codex_rev_from_tarball(tag: str) -> str:
                     if f is None:
                         continue
                     content = f.read().decode("utf-8")
-                    match = re.search(
-                        r"zed-industries/codex\?branch=acp#([a-f0-9]+)", content
+                    codex_match = re.search(
+                        r'source = "git\+https://github\.com/([^/]+)/codex\?[^"#]+#([a-f0-9]+)"',
+                        content,
                     )
-                    if match:
-                        return match.group(1)
+                    v8_match = re.search(r'name = "v8"\nversion = "([^"]+)"', content)
+                    if codex_match and v8_match:
+                        return (
+                            codex_match.group(1),
+                            codex_match.group(2),
+                            v8_match.group(1),
+                        )
 
-    msg = "Could not extract codex git revision from Cargo.lock"
+    msg = "Could not extract codex and v8 pins from Cargo.lock"
     raise ValueError(msg)
+
+
+def librusty_v8_pins(
+    v8_version: str, previous: dict[str, object] | None
+) -> dict[str, object]:
+    """Return the librusty_v8 pin for the given v8 version."""
+    print(f"V8 version: {v8_version}")
+
+    if previous and previous.get("version") == v8_version:
+        print("V8 unchanged, reusing hashes")
+        return previous
+
+    hashes = calculate_platform_hashes(
+        "https://github.com/denoland/rusty_v8/releases/download/"
+        "v{version}/librusty_v8_release_{platform}.a.gz",
+        PLATFORMS,
+        version=v8_version,
+    )
+    return {"version": v8_version, "hashes": {k: hashes[k] for k in PLATFORMS}}
 
 
 def main() -> None:
@@ -84,21 +113,20 @@ def main() -> None:
     print("Calculating source hash...")
     source_hash = calculate_url_hash(url, unpack=True)
 
-    # Extract codex git rev from Cargo.lock in the new release
-    print("Extracting codex git revision from Cargo.lock...")
-    codex_rev = extract_codex_rev_from_tarball(tag)
+    # Extract release pins from Cargo.lock in the new release
+    print("Extracting release pins from Cargo.lock...")
+    codex_owner, codex_rev, v8_version = extract_release_pins_from_tarball(tag)
+    print(f"  codexOwner: {codex_owner}")
     print(f"  codexRev: {codex_rev}")
 
     # Calculate codex source hash (needed for vendored bubblewrap on Linux)
-    codex_src_url = (
-        f"https://github.com/zed-industries/codex/archive/{codex_rev}.tar.gz"
-    )
+    codex_src_url = f"https://github.com/{codex_owner}/codex/archive/{codex_rev}.tar.gz"
     print("Calculating codex source hash...")
     codex_src_hash = calculate_url_hash(codex_src_url, unpack=True)
     print(f"  codexSrcHash: {codex_src_hash}")
 
     # Calculate node-version.txt hash
-    node_version_url = f"https://raw.githubusercontent.com/zed-industries/codex/{codex_rev}/codex-rs/node-version.txt"
+    node_version_url = f"https://raw.githubusercontent.com/{codex_owner}/codex/{codex_rev}/codex-rs/node-version.txt"
     print("Calculating node-version.txt hash...")
     node_version_hash = nix_store_prefetch_file(node_version_url)
     print(f"  nodeVersionHash: {node_version_hash}")
@@ -108,8 +136,10 @@ def main() -> None:
         "version": latest,
         "hash": source_hash,
         "cargoHash": DUMMY_SHA256_HASH,
+        "codexOwner": codex_owner,
         "codexRev": codex_rev,
         "codexSrcHash": codex_src_hash,
+        "librusty_v8": librusty_v8_pins(v8_version, data.get("librusty_v8")),
         "nodeVersionHash": node_version_hash,
     }
     save_hashes(HASHES_FILE, data)


### PR DESCRIPTION
## What changed

- updates `codex-acp` from `0.10.0` to `0.11.1`
- teaches the updater to extract the pinned Codex source from `Cargo.lock` after upstream switched from `zed-industries/codex?branch=acp` to `openai/codex?tag=...`
- prefetches `librusty_v8` as a fixed-output dependency and passes it through `RUSTY_V8_ARCHIVE`, following the existing `codex` package pattern in this repository

## Why

The previous updater and package logic assumed `codex-acp` still depended on `zed-industries/codex` on the `acp` branch. `0.11.1` now depends on tagged releases from `openai/codex`, and that dependency graph pulls in `v8`.

Without the packaging change, the build tries to download `rusty_v8` at build time, which breaks the Nix build environment.

## Impact

- `codex-acp` can be updated to `0.11.1`
- the package follows the repository convention for `rusty_v8` instead of relying on build-time network access
- future updater runs will keep the `librusty_v8` pins in sync with the `v8` version recorded in the release lockfile

## Root cause

Upstream changed `codex-acp` from the old Zed Codex fork to `openai/codex`, and the newer Codex dependency set introduced the `v8` crate. The existing package only handled the old Codex source pinning and did not vendor `rusty_v8` the way this repository already does for `codex`.

## Validation

- `python3 -m py_compile packages/codex-acp/update.py`
- updater extraction for `v0.11.1` returns the expected Codex owner, revision, and `v8` version
- `nix eval .#codex-acp.pname --raw`
- `nix build .#codex-acp --dry-run` now resolves a fixed-output `librusty_v8` dependency
- manual build confirmation on `aarch64-darwin`
