### PR TITLE
claude-code-acp: fix mainProgram to match actual npm bin name

### DIFF
--- a/packages/claude-code-acp/package.nix
+++ b/packages/claude-code-acp/package.nix
@@ -38,7 +38,7 @@ buildNpmPackage rec {
     license = licenses.asl20;
     sourceProvenance = with sourceTypes; [ fromSource ];
     maintainers = with maintainers; [ ];
-    mainProgram = "claude-code-acp";
+    mainProgram = "claude-agent-acp";
     platforms = platforms.all;
   };
 }


### PR DESCRIPTION
## Problem

`meta.mainProgram` was set to `claude-code-acp`, but the upstream npm
package at v0.24.2 exports the binary under a different name:

```json
"bin": {
  "claude-agent-acp": "dist/index.js"
}
```

This causes `lib.getExe pkgs.claude-code-acp` to resolve to a
non-existent path `.../bin/claude-code-acp`, breaking any consumer
that relies on `lib.getExe` (e.g. Zed's `agent_servers` config).

## Fix

Set `mainProgram = "claude-agent-acp"` to match what is actually
installed in `$out/bin`.

## Verification

```
$ ls $(nix build .#claude-code-acp --no-link --print-out-paths)/bin
claude-agent-acp
```