### PR TITLE
chainlink: 1.5 -> 1.6.0 & some fixes

### DIFF
--- a/packages/chainlink/nix-update-args
+++ b/packages/chainlink/nix-update-args
@@ -1,3 +1,3 @@
 --use-github-releases
 --version-regex
-^chainlink-([0-9]+\.[0-9]+)$
+^chainlink-([0-9]+\.[0-9]+(?:\.[0-9]+)?)$

--- a/packages/chainlink/package.nix
+++ b/packages/chainlink/package.nix
@@ -8,25 +8,26 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "chainlink";
-  version = "1.5";
+  version = "1.6.0";
 
   src = fetchFromGitHub {
     owner = "dollspace-gay";
     repo = "chainlink";
     rev = "chainlink-${version}";
-    hash = "sha256-K9YUTrMUwEm3q0OsH4tDqdFr39vepLQnu9vDxRX9hGY=";
+    hash = "sha256-2n+cM1ADmeDrKZKjMY5Ct4mVxl38as4iu1Y4ZSCuBho=";
   };
 
   # The Rust crate is in the chainlink subdirectory
   cargoRoot = "chainlink";
   buildAndTestSubdir = "chainlink";
 
-  cargoHash = "sha256-vBIA+N8Dro8B9XsbSxFIC3wzwSwHlBF9mBprlKI7YQA=";
+  cargoHash = "sha256-WmV6PRSuzdoCMXy4LMSMdHsSbI+A8jx89lwUt64DWmc=";
 
-  # Upstream doesn't update Cargo.toml version, patch it to match release tag
+  # Upstream Cargo.toml version doesn't match release tags, and is sporadically
+  # updated; replace it with the package version being careful to only update
+  # within [package].
   postPatch = ''
-    substituteInPlace chainlink/Cargo.toml \
-      --replace-fail 'version = "0.1.0"' 'version = "${version}.0"'
+    sed -i '/^\[package\]/,/^\[/{s/^version = ".*"/version = "${lib.versions.pad 3 version}"/}' chainlink/Cargo.toml
   '';
 
   # Tests require a writable filesystem


### PR DESCRIPTION
## Summary

It seems upstream sporadically updates the crate version, so the `postPatch` based on `substituteInPlace` can fail. Replace that with a sed command to update whatever version is present.

Additionally, generalise the `--version-regex` arg in `nix-update-args` to accept a patch version, as upstream seems to have started adding them:

    ❯ gh api repos/dollspace-gay/chainlink/tags --jq '.[].name'
    chainlink-1.6.0
    chainlink-1.5.1
    chainlink-1.5
    chainlink-1.4
    chainlink-1.3
    chainlink-1.2
    chainlink-1.1
    chainlink-1.0

## Test plan

- [x] `nix build .#<package>` succeeds
- [x] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work
