### PR TITLE
hermes-agent: add mcp dependency

### DIFF
--- a/packages/hermes-agent/package.nix
+++ b/packages/hermes-agent/package.nix
@@ -151,6 +151,8 @@ python3.pkgs.buildPythonApplication rec {
     pydantic
     # Interactive CLI
     prompt-toolkit
+    # MCP
+    mcp
     # Tools
     exa-py
     firecrawl-py


### PR DESCRIPTION
Summary:
- add the Python `mcp` dependency to the hermes-agent package

Why:
- Hermes' upstream MCP support is optional and relies on the Python `mcp` package
- HTTP MCP servers such as GitHub Copilot require `mcp.client.streamable_http`
- without `mcp` in the package closure, `hermes mcp test github` fails with:
  `mcp.client.streamable_http is not available. Upgrade the mcp package to get HTTP support.`

Validation:
- `nix build --accept-flake-config .#hermes-agent --no-link`
- `nix run --accept-flake-config .#hermes-agent -- --version`
- verified the built wrapper now includes `python3.13-mcp-1.26.0` in the runtime environment