### PR TITLE
README: Note about flake input follows

### DIFF
--- a/README.md
+++ b/README.md
@@ -858,6 +858,16 @@ Add to your system configuration:
 }
 ```
 
+> [!NOTE]
+> This flake is only built and tested against its pinned `nixpkgs-unstable`
+> input. If you set `llm-agents.inputs.nixpkgs.follows = "nixpkgs"`, your
+> `nixpkgs` must also track `nixpkgs-unstable` and be reasonably current —
+> using a stable release branch (e.g. `nixos-25.05`) **will** break eventually.
+> Omitting `follows` costs you a second nixpkgs evaluation but guarantees you
+> get the combination we ship in CI — and lets you pull pre-built binaries
+> from our [binary cache](#binary-cache) instead of rebuilding everything
+> against your nixpkgs.
+
 ### Using Overlay
 
 Alternatively, use the overlay to access packages under the `llm-agents` namespace:


### PR DESCRIPTION
In https://github.com/numtide/llm-agents.nix/issues/3732 I ran into a build failure that appears to be caused by a change in the Nixpkgs API, since I was pinning the Flake inputs passed to `llm-agents`.

Add a note to help others avoid making the same mistake.

## Summary

<!-- Briefly describe what this PR does -->

## Test plan

<!-- How did you test this change? -->

- [ ] `nix build .#<package>` succeeds
- [ ] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
