### PR TITLE
gemini-cli: fix keytar.node missing from output

### DIFF
--- a/packages/gemini-cli/package.nix
+++ b/packages/gemini-cli/package.nix
@@ -129,7 +129,12 @@ buildNpmPackage (finalAttrs: {
       -o -name "config.gypi" \
       -o -path '*/build/*.mk' -o -path '*/build/Makefile' \
       | xargs rm -f
-    rm -rf $out/share/gemini-cli/node_modules/keytar/build
+    # keytar/build: keep only the runtime addon. Object files and .deps/*.d
+    # embed paths to nodejs-source and -dev outputs, bloating the closure.
+    find $out/share/gemini-cli/node_modules/keytar/build \
+      -type f -not -name 'keytar.node' -delete
+    find $out/share/gemini-cli/node_modules/keytar/build \
+      -type d -empty -delete
   '';
 
   doInstallCheck = true;


### PR DESCRIPTION
Fixes #3740

The closure-shrinking commit 6cc84a0f deleted the entire `keytar/build` directory, including the compiled `keytar.node` addon required at runtime. Result:

```
Keychain initialization encountered an error: Cannot find module '../build/Release/keytar.node'
Using FileKeychain fallback for secure storage.
```

**Fix:** keep `keytar.node`, delete everything else in `build/` (.o, .deps/*.d, binding.Makefile reference nodejs-source/-dev outputs).

**Tested:**
- `disallowedReferences` still satisfied (python/npmDeps not in closure)
- `gemini --version` no longer prints keychain error
- Closure +21 MiB (libsecret/glib/libgcrypt — actual runtime deps of the now-working keytar.node)