### PR TITLE
claw-code: init at 0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>claw-code</strong> - Claude Code rewrite CLI built from the official claw-code Rust workspace</summary>
+
+- **Source**: source
+- **License**: MIT
+- **Homepage**: https://github.com/ultraworkers/claw-code
+- **Usage**: `nix run github:numtide/llm-agents.nix#claw-code -- --help`
+- **Nix**: [packages/claw-code/package.nix](packages/claw-code/package.nix)
+
+</details>
+<details>
 <summary><strong>cli-proxy-api</strong> - Unified proxy providing OpenAI/Gemini/Claude/Codex compatible APIs for AI coding CLI tools</summary>
 
 - **Source**: source

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -87,6 +87,11 @@ inputs.nixpkgs.lib.extend (
         githubId = 25645555;
         name = "Pieter Pel";
       };
+      smdex = {
+        github = "smdex";
+        githubId = 105790745;
+        name = "Sergii Maksymov";
+      };
     };
   }
 )

--- a/packages/claw-code/default.nix
+++ b/packages/claw-code/default.nix
@@ -1,0 +1,8 @@
+{
+  pkgs,
+  flake,
+  ...
+}:
+pkgs.callPackage ./package.nix {
+  inherit flake;
+}

--- a/packages/claw-code/package.nix
+++ b/packages/claw-code/package.nix
@@ -3,6 +3,7 @@
   flake,
   fetchFromGitHub,
   rustPlatform,
+  git,
   versionCheckHook,
 }:
 
@@ -25,8 +26,21 @@ rustPlatform.buildRustPackage rec {
     "--package"
     "rusty-claude-cli"
   ];
+  cargoTestFlags = cargoBuildFlags;
 
-  doCheck = false;
+  nativeCheckInputs = [ git ];
+
+  preCheck = ''
+    export HOME=$TMPDIR
+  '';
+
+  checkFlags = [
+    # broken upstream at this rev: tool allow-list assertions out of sync with implementation
+    "--skip=tests::rejects_unknown_allowed_tools"
+    "--skip=tests::build_runtime_plugin_state_discovers_mcp_tools_and_surfaces_pending_servers"
+    # integration harness expects scripted plugin fixtures not present in sandbox
+    "--skip=clean_env_cli_reaches_mock_anthropic_service_across_scripted_parity_scenarios"
+  ];
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];

--- a/packages/claw-code/package.nix
+++ b/packages/claw-code/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  flake,
+  fetchFromGitHub,
+  rustPlatform,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "claw-code";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "ultraworkers";
+    repo = "claw-code";
+    rev = "4f670e5513db1ed485e8c822ef404a48e8129028";
+    hash = "sha256-qghvVytVPV8/WDMEKRGGMYN+CPG1+aQepXgtJ3ibDVA=";
+  };
+
+  sourceRoot = "source/rust";
+
+  cargoHash = "sha256-P8QqUM1s/fNv7Fb4dmpJWDfTNumgUu1Cdiln8ybSDUU=";
+
+  cargoBuildFlags = [
+    "--package"
+    "rusty-claude-cli"
+  ];
+
+  doCheck = false;
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = [ "--version" ];
+
+  passthru.category = "AI Coding Agents";
+
+  meta = {
+    description = "Claude Code rewrite CLI built from the official claw-code Rust workspace";
+    homepage = "https://github.com/ultraworkers/claw-code";
+    changelog = "https://github.com/ultraworkers/claw-code/releases";
+    license = lib.licenses.mit;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    maintainers = with flake.lib.maintainers; [ smdex ];
+    mainProgram = "claw";
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
## Summary
- Rebased the claw-code package onto `upstream/main` so the branch contains only the claw-code package commit.
- This supersedes PR #3863, which was contaminated by unrelated historical commits from the personal branch.

## Verification
- `nix build --accept-flake-config .#claw-code`
- `result/bin/claw --version`