### PR TITLE
handy: use bundled libonnxruntime to fix VERS_1.24.2 load error

### DIFF
--- a/packages/handy/package.nix
+++ b/packages/handy/package.nix
@@ -17,7 +17,6 @@
   gtk-layer-shell,
   libayatana-appindicator,
   libsoup_3,
-  onnxruntime,
   openssl,
   vulkan-loader,
   webkitgtk_4_1,
@@ -84,7 +83,6 @@ stdenv.mkDerivation {
     gtk3
     gtk-layer-shell
     libsoup_3
-    onnxruntime
     openssl
     vulkan-loader
     webkitgtk_4_1
@@ -123,6 +121,13 @@ stdenv.mkDerivation {
 
         # Install the binary
         install -Dm755 usr/bin/handy $out/bin/handy
+
+        # Install the bundled onnxruntime. Upstream onnxruntime tags its
+        # exported symbols with a VERS_<exact-version> ELF symbol version, so
+        # the prebuilt handy binary can only load the exact libonnxruntime
+        # version it was linked against and is not compatible with whatever
+        # version nixpkgs currently ships.
+        install -Dm755 usr/lib/libonnxruntime.so.1 $out/lib/libonnxruntime.so.1
 
         # Install resources
         mkdir -p $out/lib/Handy/resources


### PR DESCRIPTION
## Summary

`handy` fails to start with `` version `VERS_1.24.2` not found `` because onnxruntime tags its exported symbols with a `VERS_<exact-version>` ELF symbol version. The prebuilt binary was linked against 1.24.2, but nixpkgs ships 1.24.4, so the dynamic loader rejects it. The upstream .deb already bundles the matching `libonnxruntime.so` — we were just throwing it away. This installs the bundled library into `$out/lib` (autoPatchelfHook handles its libstdc++/glibc deps) and drops the nixpkgs `onnxruntime` input, making the package robust against future nixpkgs onnxruntime bumps.

Fixes #3847

## Test plan

- [x] `nix build .#handy` succeeds
- [x] `ldd $out/bin/handy` resolves `libonnxruntime.so.1` to `$out/lib`, no missing libs
- [x] `handy --help` runs (previously aborted at load time)
- [x] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.