### PR TITLE
fix(omp): link vendored glimmer scanner

### DIFF
--- a/packages/omp/package.nix
+++ b/packages/omp/package.nix
@@ -56,6 +56,14 @@ stdenv.mkDerivation {
   # smallvec's `specialization` feature requires nightly Rust.
   # RUSTC_BOOTSTRAP=1 enables nightly features on stable rustc.
   env.RUSTC_BOOTSTRAP = 1;
+  env.RUSTFLAGS = lib.concatStringsSep " " [
+    "-Clink-arg=-Wl,-u,tree_sitter_glimmer_external_scanner_create"
+    "-Clink-arg=-Wl,-u,tree_sitter_glimmer_external_scanner_destroy"
+    "-Clink-arg=-Wl,-u,tree_sitter_glimmer_external_scanner_reset"
+    "-Clink-arg=-Wl,-u,tree_sitter_glimmer_external_scanner_scan"
+    "-Clink-arg=-Wl,-u,tree_sitter_glimmer_external_scanner_serialize"
+    "-Clink-arg=-Wl,-u,tree_sitter_glimmer_external_scanner_deserialize"
+  ];
 
   bunDeps = bun2nix.fetchBunDeps {
     bunNix = ./bun.nix;


### PR DESCRIPTION
## Summary

Fix `omp` on Linux by forcing the vendored `tree-sitter-glimmer` scanner symbols to be retained during linking.

Without this, `omp --help` fails at startup when loading `pi_natives` with: 

`undefined symbol: tree_sitter_glimmer_external_scanner_create`

## Change

Add linker `-u` flags to `packages/omp/package.nix` so the glimmer external scanner symbols are kept in the final native addon.

## Validation

- `nix build path:$PWD#omp`
- `ldd -r result/lib/omp/pi_natives.linux-x64.node`
- `result/bin/omp --help`

Before this patch, `omp --help` failed with the missing `tree_sitter_glimmer_*` symbols.
After this patch, it starts normally.