### PR TITLE
but: init at 0.19.7

### DIFF
--- a/packages/but/default.nix
+++ b/packages/but/default.nix
@@ -1,0 +1,8 @@
+{
+  pkgs,
+  flake,
+  ...
+}:
+pkgs.callPackage ./package.nix {
+  inherit flake;
+}

--- a/packages/but/package.nix
+++ b/packages/but/package.nix
@@ -1,0 +1,88 @@
+{
+  lib,
+  flake,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  openssl,
+  sqlite,
+  zstd,
+  dbus,
+  stdenv,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "but";
+  version = "0.19.7";
+
+  src = fetchFromGitHub {
+    owner = "gitbutlerapp";
+    repo = "gitbutler";
+    tag = "release/${finalAttrs.version}";
+    hash = "sha256-ppl1noikPwTvG/XT7iYG41+9ZZO8i0x2L+odeEzRP1s=";
+  };
+
+  cargoHash = "sha256-xW/eO+AQQUBN2MrixNx3LKhwMookkKuX5LF4DSWQKKY=";
+
+  # Upstream pins a specific stable channel; allow building with nixpkgs' rustc.
+  postPatch = ''
+    rm -f rust-toolchain.toml
+  '';
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    openssl
+    sqlite
+    zstd
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    dbus
+  ];
+
+  env = {
+    # Upstream reads the user-facing version from $VERSION at build time
+    # (set by their release pipeline); without it `but --version` reports "dev".
+    VERSION = finalAttrs.version;
+    # CHANNEL=release makes the binary use the production app identifier.
+    CHANNEL = "release";
+    OPENSSL_NO_VENDOR = "1";
+    ZSTD_SYS_USE_PKG_CONFIG = "1";
+    # Avoid generating TypeScript bindings into the source tree during build.
+    TS_RS_EXPORT_DIR = "/build/ts-rs";
+  };
+
+  cargoBuildFlags = [
+    "--package=but"
+  ];
+  # Signal that the binary is distributed via a package manager so it
+  # disables self-update / `but update install` codepaths.
+  buildFeatures = [ "but/packaged-but-distribution" ];
+
+  # The workspace test suite requires git fixtures, network access and the
+  # full Tauri/GUI stack; the CLI itself is exercised via versionCheckHook.
+  doCheck = false;
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+
+  passthru.category = "Workflow & Project Management";
+
+  meta = with lib; {
+    description = "GitButler CLI - virtual branches and AI-assisted Git workflow from the terminal";
+    homepage = "https://github.com/gitbutlerapp/gitbutler";
+    changelog = "https://github.com/gitbutlerapp/gitbutler/releases/tag/release/${finalAttrs.version}";
+    # Functional Source License 1.1 (MIT future license)
+    license = {
+      fullName = "Functional Source License, Version 1.1, MIT Future License";
+      url = "https://github.com/gitbutlerapp/gitbutler/blob/master/LICENSE.md";
+      free = false;
+    };
+    sourceProvenance = with sourceTypes; [ fromSource ];
+    maintainers = with flake.lib.maintainers; [ mic92 ];
+    mainProgram = "but";
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+})


### PR DESCRIPTION
Package the GitButler CLI from source so the virtual-branch workflow is available without the Tauri desktop app. The build enables the upstream packaged-but-distribution feature so the binary does not attempt to self-update from the Nix store, and skips the workspace test suite which depends on git fixtures and the GUI stack.

## Summary

<!-- Briefly describe what this PR does -->

## Test plan

<!-- How did you test this change? -->

- [ ] `nix build .#<package>` succeeds
- [ ] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
