### PR TITLE
copilot-cli: default COPILOT_AUTO_UPDATE/USE_BUILTIN_RIPGREP to false

### DIFF
--- a/packages/copilot-cli/package.nix
+++ b/packages/copilot-cli/package.nix
@@ -6,6 +6,7 @@
   wrapBuddy,
   cacert,
   nodejs_24,
+  ripgrep,
   versionCheckHook,
 }:
 
@@ -31,7 +32,10 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir -p $out/bin
     makeWrapper ${nodejs_24}/bin/node $out/bin/copilot \
       --add-flags "$out/lib/${finalAttrs.pname}/index.js" \
-      --set SSL_CERT_DIR "${cacert}/etc/ssl/certs"
+      --set SSL_CERT_DIR "${cacert}/etc/ssl/certs" \
+      --set-default COPILOT_AUTO_UPDATE false \
+      --set-default USE_BUILTIN_RIPGREP false \
+      --prefix PATH : ${lib.makeBinPath [ ripgrep ]}
 
     runHook postInstall
   '';


### PR DESCRIPTION
## Summary

Set sane defaults for two `copilot-cli` environment variables via the wrapper. `COPILOT_AUTO_UPDATE=false` because the auto-updater cannot replace files in an immutable Nix store path and only nags users about updates that should come through Nix. `USE_BUILTIN_RIPGREP=false` (with nixpkgs `ripgrep` added to `PATH`) so we use a reproducible, properly built `rg` instead of the vendored prebuilt blob. Both use `--set-default` so users can still override.

Fixes #3897
Fixes #3898

## Test plan

- [x] `nix build .#copilot-cli` succeeds (versionCheckHook passes, wrapper contains the expected `--set-default` exports and ripgrep on `PATH`)
- [x] Package updates via `nix-update` or has a custom `update.py` if nix-update does not work

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.