### PR TITLE
copilot-cli: add interactive bash to path to fix use in `nix develop` environments

### DIFF
--- a/packages/copilot-cli/package.nix
+++ b/packages/copilot-cli/package.nix
@@ -7,6 +7,7 @@
   cacert,
   nodejs_24,
   ripgrep,
+  bash,
   versionCheckHook,
 }:
 
@@ -35,7 +36,12 @@ stdenv.mkDerivation (finalAttrs: {
       --set SSL_CERT_DIR "${cacert}/etc/ssl/certs" \
       --set-default COPILOT_AUTO_UPDATE false \
       --set-default USE_BUILTIN_RIPGREP false \
-      --prefix PATH : ${lib.makeBinPath [ ripgrep ]}
+      --prefix PATH : ${
+        lib.makeBinPath [
+          ripgrep
+          bash
+        ]
+      }
 
     runHook postInstall
   '';


### PR DESCRIPTION
## Summary

<!-- Briefly describe what this PR does -->
A `nix develop` environment (note: `nix-shell` environments work fine however) adds a
non-interactive bash (`bashNonInteractive`) to early in `PATH`, which breaks copilot's shell
commands with errors like:
```bash
❯ Try running a series of commands and see if you see their output

● Running a few diagnostic shell commands (pwd, ls, uname, date, whoami, id, env, git status, df) to capture their output. This shows current directory contents and basic system info. Now
  executing the commands.

● Run diagnostic shell commands (shell)
  │ pwd ; echo '--- ls -la ---' ; ls -la --color=never || true ; echo '--- uname -a ---' ; uname -a || true ; echo '--- date ---' ; date -u || true ; echo '--- whoami ---' ; whoami || true ;
  │ echo '--- id ---' ; id || true ; echo '--- env (head) ---' ; env | sort | head -n 50 || true ; echo '--- git status ---' ; git --no-pager status || true ; echo '--- df -h . ---' ; df -h .
  │ || true
  └ 1 line...

✗ Read shell output Waiting up to 2 seconds for command output
  └ Invalid shell ID: 0. Please supply a valid shell ID to read output from.

    <no active shell sessions>
```

Adding the interactive bash to the wrapper makes its `bash` resolve to the proper one

NixOS/nixpkgs#509133 for a similar change to nixpkgs

## Test plan
<!-- How did you test this change? -->
1. Enter a devshell (which does not list `bash` in its packages) with `nix develop`
2. Start copilot and ask it to run commands
3. Would fail earlier, works now

- [x] `nix build .#<package>` succeeds
- [ ] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
