### PR TITLE
oh-my-opencode: 3.16.0 -> 3.17.0, fix stale bun.lock

### DIFF
--- a/packages/oh-my-opencode/bun.nix
+++ b/packages/oh-my-opencode/bun.nix
@@ -110,6 +110,10 @@
     url = "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.4.0.tgz";
     hash = "sha512-mfa3MzhqNM+Az4bgPDDXL3NdG+aYOHClXmT6/4qLxf2ulyfPpMNHqb9Dfmo4D8UfmrDsPuJHmbune73/nUQnuw==";
   };
+  "@posthog/core@1.25.2" = fetchurl {
+    url = "https://registry.npmjs.org/@posthog/core/-/core-1.25.2.tgz";
+    hash = "sha512-h2FO7ut/BbfwpAXWpwdDHTzQgUo9ibDFEs6ZO+3cI3KPWQt5XwczK1OLAuPprcjm8T/jl0SH8jSFo5XdU4RbTg==";
+  };
   "@types/js-yaml@4.0.9" = fetchurl {
     url = "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz";
     hash = "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==";
@@ -382,6 +386,50 @@
     url = "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz";
     hash = "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==";
   };
+  "oh-my-opencode-darwin-arm64@3.17.0" = fetchurl {
+    url = "https://registry.npmjs.org/oh-my-opencode-darwin-arm64/-/oh-my-opencode-darwin-arm64-3.17.0.tgz";
+    hash = "sha512-d8VHKSjR4gWwQ7rvYn2bU+v+I3KlcgqGc0R38WCn4ZiyfTJECcOVzhOVKt4hKfJgbH2uNjpJ5eM41jPP6oJRjA==";
+  };
+  "oh-my-opencode-darwin-x64-baseline@3.17.0" = fetchurl {
+    url = "https://registry.npmjs.org/oh-my-opencode-darwin-x64-baseline/-/oh-my-opencode-darwin-x64-baseline-3.17.0.tgz";
+    hash = "sha512-ej4XZdt3aRpUL3mSIp5SHRDmoTdeojdgkxqF5s/6Gv79NomCIhQLNVs6yRhUihrWkVwclAkKXHM6+UkGNbWQQw==";
+  };
+  "oh-my-opencode-darwin-x64@3.17.0" = fetchurl {
+    url = "https://registry.npmjs.org/oh-my-opencode-darwin-x64/-/oh-my-opencode-darwin-x64-3.17.0.tgz";
+    hash = "sha512-m4ir/TpacyobUFQ9xcKHq1Tn4JLHvwrOWmoJk59VQPDMUIaGWhfafgBuRFFKIkXIXRKBP1pEnV+PYGolPRBUGg==";
+  };
+  "oh-my-opencode-linux-arm64-musl@3.17.0" = fetchurl {
+    url = "https://registry.npmjs.org/oh-my-opencode-linux-arm64-musl/-/oh-my-opencode-linux-arm64-musl-3.17.0.tgz";
+    hash = "sha512-oR0EwN9jbhshhdomnV9zv5KNfsv0LWP3G21yhBkTPc2DtzUPQ0WEhG0qgbVPV8z9rq3HsB/L0CIg+/D/CGavPQ==";
+  };
+  "oh-my-opencode-linux-arm64@3.17.0" = fetchurl {
+    url = "https://registry.npmjs.org/oh-my-opencode-linux-arm64/-/oh-my-opencode-linux-arm64-3.17.0.tgz";
+    hash = "sha512-xww4j2wRwxA0M7YpM5DT9ZScEajW9aDr5+NNoIqJQwIRCkKShmDvyhxbi/zTXLiyhu0HNySoLfN5iqfhIvNl9w==";
+  };
+  "oh-my-opencode-linux-x64-baseline@3.17.0" = fetchurl {
+    url = "https://registry.npmjs.org/oh-my-opencode-linux-x64-baseline/-/oh-my-opencode-linux-x64-baseline-3.17.0.tgz";
+    hash = "sha512-FaWPECkzdnT5CkHPgWsMbpsXK8vC+YgqxmBJ5SdwRb8aeRk0+ySF96dTp4rz6xkegmkwC7XXfmmW5bu9yQjzyg==";
+  };
+  "oh-my-opencode-linux-x64-musl-baseline@3.17.0" = fetchurl {
+    url = "https://registry.npmjs.org/oh-my-opencode-linux-x64-musl-baseline/-/oh-my-opencode-linux-x64-musl-baseline-3.17.0.tgz";
+    hash = "sha512-WxwUW0VWDle78U0xtF7lrcYUWB6EXf+lLBZJue3HWS4wpyTAYlynGgnZJCnG0l8bc9RLJIe4VvvmiZSFuxNIEg==";
+  };
+  "oh-my-opencode-linux-x64-musl@3.17.0" = fetchurl {
+    url = "https://registry.npmjs.org/oh-my-opencode-linux-x64-musl/-/oh-my-opencode-linux-x64-musl-3.17.0.tgz";
+    hash = "sha512-JHEIjWvhB0Z5kHNhXirTsW7YzTb4IbV//LVCmQuhpoyDC7GeN3Wka3OPSBnTgnqw1SMvm0c6G7gNvDqeZNgzUg==";
+  };
+  "oh-my-opencode-linux-x64@3.17.0" = fetchurl {
+    url = "https://registry.npmjs.org/oh-my-opencode-linux-x64/-/oh-my-opencode-linux-x64-3.17.0.tgz";
+    hash = "sha512-9uNbkDhJIsaTCxF+A0KOUxES0vasw+8LD9uEdN0BBgjtvQZ67XaHsPUZkSGBYzeTJgJVOImq/fwzINhqxfXahw==";
+  };
+  "oh-my-opencode-windows-x64-baseline@3.17.0" = fetchurl {
+    url = "https://registry.npmjs.org/oh-my-opencode-windows-x64-baseline/-/oh-my-opencode-windows-x64-baseline-3.17.0.tgz";
+    hash = "sha512-wyv/OHC/SrJVYGWMu9wD7+PUcmp87v38zBgMduqOn5PIUkmwIPOXF7tOdPeIQsch3/m/CK01RuZJ8NHAMA0bGA==";
+  };
+  "oh-my-opencode-windows-x64@3.17.0" = fetchurl {
+    url = "https://registry.npmjs.org/oh-my-opencode-windows-x64/-/oh-my-opencode-windows-x64-3.17.0.tgz";
+    hash = "sha512-XnIR++Kw1s+5MOZLqoBTCWyYaXT03JAR+5/7zYU1b5JEbQuM5L/zKXjUScXnVUHMkqtYpxUZLE7Nk6ldUyWNaA==";
+  };
   "on-finished@2.4.1" = fetchurl {
     url = "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz";
     hash = "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==";
@@ -413,6 +461,10 @@
   "pkce-challenge@5.0.1" = fetchurl {
     url = "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz";
     hash = "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==";
+  };
+  "posthog-node@5.29.2" = fetchurl {
+    url = "https://registry.npmjs.org/posthog-node/-/posthog-node-5.29.2.tgz";
+    hash = "sha512-rI7kkF0XqDc0G1qjx+Hb4iuY9NAlL+XQNoGOpnEpRNTUcXvjY6WlsRGZ9m2whgc39emrrYdszi/YT8wZkr2xsg==";
   };
   "proxy-addr@2.0.7" = fetchurl {
     url = "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz";

--- a/packages/oh-my-opencode/fix-stale-bun-lock.patch
+++ b/packages/oh-my-opencode/fix-stale-bun-lock.patch
@@ -1,0 +1,62 @@
+diff --git a/bun.lock b/bun.lock
+index 32e143f..f7e37f7 100644
+--- a/bun.lock
++++ b/bun.lock
+@@ -30,17 +30,17 @@
+         "typescript": "^5.7.3",
+       },
+       "optionalDependencies": {
+-        "oh-my-opencode-darwin-arm64": "3.16.0",
+-        "oh-my-opencode-darwin-x64": "3.16.0",
+-        "oh-my-opencode-darwin-x64-baseline": "3.16.0",
+-        "oh-my-opencode-linux-arm64": "3.16.0",
+-        "oh-my-opencode-linux-arm64-musl": "3.16.0",
+-        "oh-my-opencode-linux-x64": "3.16.0",
+-        "oh-my-opencode-linux-x64-baseline": "3.16.0",
+-        "oh-my-opencode-linux-x64-musl": "3.16.0",
+-        "oh-my-opencode-linux-x64-musl-baseline": "3.16.0",
+-        "oh-my-opencode-windows-x64": "3.16.0",
+-        "oh-my-opencode-windows-x64-baseline": "3.16.0",
++        "oh-my-opencode-darwin-arm64": "3.17.0",
++        "oh-my-opencode-darwin-x64": "3.17.0",
++        "oh-my-opencode-darwin-x64-baseline": "3.17.0",
++        "oh-my-opencode-linux-arm64": "3.17.0",
++        "oh-my-opencode-linux-arm64-musl": "3.17.0",
++        "oh-my-opencode-linux-x64": "3.17.0",
++        "oh-my-opencode-linux-x64-baseline": "3.17.0",
++        "oh-my-opencode-linux-x64-musl": "3.17.0",
++        "oh-my-opencode-linux-x64-musl-baseline": "3.17.0",
++        "oh-my-opencode-windows-x64": "3.17.0",
++        "oh-my-opencode-windows-x64-baseline": "3.17.0",
+       },
+     },
+   },
+@@ -238,6 +238,28 @@
+ 
+     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+ 
++    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@3.17.0", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-d8VHKSjR4gWwQ7rvYn2bU+v+I3KlcgqGc0R38WCn4ZiyfTJECcOVzhOVKt4hKfJgbH2uNjpJ5eM41jPP6oJRjA=="],
++
++    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@3.17.0", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-m4ir/TpacyobUFQ9xcKHq1Tn4JLHvwrOWmoJk59VQPDMUIaGWhfafgBuRFFKIkXIXRKBP1pEnV+PYGolPRBUGg=="],
++
++    "oh-my-opencode-darwin-x64-baseline": ["oh-my-opencode-darwin-x64-baseline@3.17.0", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-ej4XZdt3aRpUL3mSIp5SHRDmoTdeojdgkxqF5s/6Gv79NomCIhQLNVs6yRhUihrWkVwclAkKXHM6+UkGNbWQQw=="],
++
++    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@3.17.0", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-xww4j2wRwxA0M7YpM5DT9ZScEajW9aDr5+NNoIqJQwIRCkKShmDvyhxbi/zTXLiyhu0HNySoLfN5iqfhIvNl9w=="],
++
++    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@3.17.0", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-oR0EwN9jbhshhdomnV9zv5KNfsv0LWP3G21yhBkTPc2DtzUPQ0WEhG0qgbVPV8z9rq3HsB/L0CIg+/D/CGavPQ=="],
++
++    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@3.17.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-9uNbkDhJIsaTCxF+A0KOUxES0vasw+8LD9uEdN0BBgjtvQZ67XaHsPUZkSGBYzeTJgJVOImq/fwzINhqxfXahw=="],
++
++    "oh-my-opencode-linux-x64-baseline": ["oh-my-opencode-linux-x64-baseline@3.17.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-FaWPECkzdnT5CkHPgWsMbpsXK8vC+YgqxmBJ5SdwRb8aeRk0+ySF96dTp4rz6xkegmkwC7XXfmmW5bu9yQjzyg=="],
++
++    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@3.17.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-JHEIjWvhB0Z5kHNhXirTsW7YzTb4IbV//LVCmQuhpoyDC7GeN3Wka3OPSBnTgnqw1SMvm0c6G7gNvDqeZNgzUg=="],
++
++    "oh-my-opencode-linux-x64-musl-baseline": ["oh-my-opencode-linux-x64-musl-baseline@3.17.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-WxwUW0VWDle78U0xtF7lrcYUWB6EXf+lLBZJue3HWS4wpyTAYlynGgnZJCnG0l8bc9RLJIe4VvvmiZSFuxNIEg=="],
++
++    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@3.17.0", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-XnIR++Kw1s+5MOZLqoBTCWyYaXT03JAR+5/7zYU1b5JEbQuM5L/zKXjUScXnVUHMkqtYpxUZLE7Nk6ldUyWNaA=="],
++
++    "oh-my-opencode-windows-x64-baseline": ["oh-my-opencode-windows-x64-baseline@3.17.0", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-wyv/OHC/SrJVYGWMu9wD7+PUcmp87v38zBgMduqOn5PIUkmwIPOXF7tOdPeIQsch3/m/CK01RuZJ8NHAMA0bGA=="],
++
+     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+ 
+     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],

--- a/packages/oh-my-opencode/hashes.json
+++ b/packages/oh-my-opencode/hashes.json
@@ -1,4 +1,4 @@
 {
-  "version": "3.16.0",
-  "hash": "sha256-tQeJpx2/SYicI4HqS8mxqUzYojqXZlEpt3ckc5o6xeo="
+  "version": "3.17.0",
+  "hash": "sha256-sCPLdHKcFGSmSfGaAqCdisqK9lpD0E7UKOkLtEU/erQ="
 }

--- a/packages/oh-my-opencode/package.nix
+++ b/packages/oh-my-opencode/package.nix
@@ -24,6 +24,9 @@ stdenv.mkDerivation {
     inherit hash;
   };
 
+  # Non-empty when upstream ships a stale bun.lock; kept in sync by update.py
+  patches = lib.optional (builtins.readFile ./fix-stale-bun-lock.patch != "") ./fix-stale-bun-lock.patch;
+
   nativeBuildInputs = [
     bun2nix.hook
     bun

--- a/packages/oh-my-opencode/package.nix
+++ b/packages/oh-my-opencode/package.nix
@@ -25,7 +25,9 @@ stdenv.mkDerivation {
   };
 
   # Non-empty when upstream ships a stale bun.lock; kept in sync by update.py
-  patches = lib.optional (builtins.readFile ./fix-stale-bun-lock.patch != "") ./fix-stale-bun-lock.patch;
+  patches = lib.optional (
+    builtins.readFile ./fix-stale-bun-lock.patch != ""
+  ) ./fix-stale-bun-lock.patch;
 
   nativeBuildInputs = [
     bun2nix.hook

--- a/packages/oh-my-opencode/update.py
+++ b/packages/oh-my-opencode/update.py
@@ -63,6 +63,7 @@ def main() -> None:
         BUN_NIX,
         FLAKE_ROOT,
         ref_prefix="v",
+        pkg_dir=PKG_DIR,
     )
 
     print(f"Updated oh-my-opencode to {latest}")

--- a/scripts/updater/bun.py
+++ b/scripts/updater/bun.py
@@ -165,7 +165,9 @@ def clone_and_generate_bun_nix(
                 # Generate the diff and save it so the Nix build can apply it.
                 diff_result = run_command(["git", "diff", "bun.lock"], cwd=repo_dir)
                 patch_file.write_text(diff_result.stdout)
-                print(f"⚠️  Upstream bun.lock was stale — wrote patch to {patch_file.name}")
+                print(
+                    f"⚠️  Upstream bun.lock was stale — wrote patch to {patch_file.name}"
+                )
             else:
                 msg = (
                     f"Upstream {owner}/{repo} {ref} has a stale bun.lock "

--- a/scripts/updater/bun.py
+++ b/scripts/updater/bun.py
@@ -4,6 +4,8 @@ Provides helpers for regenerating bun.nix lockfiles using bun2nix,
 used by packages that depend on the bun2nix flake input.
 """
 
+from __future__ import annotations
+
 import subprocess
 import tempfile
 from pathlib import Path
@@ -68,6 +70,7 @@ def clone_and_generate_bun_nix(
     flake_root: Path,
     *,
     ref_prefix: str = "",
+    pkg_dir: Path | None = None,
 ) -> None:
     """Clone a repo at a given version and regenerate bun.nix from its bun.lock.
 
@@ -77,6 +80,12 @@ def clone_and_generate_bun_nix(
     Always runs ``bun install`` to ensure bun.lock is consistent with
     package.json (upstream lockfiles are sometimes stale).
 
+    When the upstream lockfile is stale and ``pkg_dir`` is provided, a patch
+    file ``fix-stale-bun-lock.patch`` is written into ``pkg_dir`` so that the
+    Nix build can apply it at build time.  When the lockfile is fresh, any
+    existing patch file in ``pkg_dir`` is removed so it does not break future
+    builds.
+
     Args:
         owner: GitHub repository owner
         repo: GitHub repository name
@@ -84,6 +93,8 @@ def clone_and_generate_bun_nix(
         bun_nix_output: Path where bun.nix should be written
         flake_root: Root directory of the flake
         ref_prefix: Prefix for the git ref (e.g. "v" for "v1.0.0" tags)
+        pkg_dir: Package directory; when set, stale-lockfile patches are
+            written here automatically instead of raising an error.
 
     """
     ref = f"{ref_prefix}{version}"
@@ -147,22 +158,32 @@ def clone_and_generate_bun_nix(
 
         regenerate_bun_nix(bun_lock, bun_nix_output, flake_root)
 
+        patch_file = pkg_dir / "fix-stale-bun-lock.patch" if pkg_dir else None
+
         if lockfile_was_stale:
-            msg = (
-                f"Upstream {owner}/{repo} {ref} has a stale bun.lock "
-                f"that does not match package.json.\n"
-                f"bun.nix was regenerated from the refreshed lockfile, "
-                f"but the Nix build will still use the stale in-tree "
-                f"bun.lock from the source tarball.\n"
-                f"You need to add a patch that fixes bun.lock at build "
-                f"time (see packages/qmd/fix-stale-bun-lock.patch for "
-                f"an example).\n"
-                f"\n"
-                f"To generate the patch:\n"
-                f"  git clone --depth=1 --branch={ref} "
-                f"https://github.com/{owner}/{repo}.git /tmp/{repo}\n"
-                f"  cd /tmp/{repo}\n"
-                f"  bun install --lockfile-only\n"
-                f"  git diff bun.lock > fix-stale-bun-lock.patch\n"
-            )
-            raise RuntimeError(msg)
+            if patch_file is not None:
+                # Generate the diff and save it so the Nix build can apply it.
+                diff_result = run_command(["git", "diff", "bun.lock"], cwd=repo_dir)
+                patch_file.write_text(diff_result.stdout)
+                print(f"⚠️  Upstream bun.lock was stale — wrote patch to {patch_file.name}")
+            else:
+                msg = (
+                    f"Upstream {owner}/{repo} {ref} has a stale bun.lock "
+                    f"that does not match package.json.\n"
+                    f"bun.nix was regenerated from the refreshed lockfile, "
+                    f"but the Nix build will still use the stale in-tree "
+                    f"bun.lock from the source tarball.\n"
+                    f"You need to add a patch that fixes bun.lock at build "
+                    f"time.\n"
+                    f"\n"
+                    f"To generate the patch:\n"
+                    f"  git clone --depth=1 --branch={ref} "
+                    f"https://github.com/{owner}/{repo}.git /tmp/{repo}\n"
+                    f"  cd /tmp/{repo}\n"
+                    f"  bun install --lockfile-only\n"
+                    f"  git diff bun.lock > fix-stale-bun-lock.patch\n"
+                )
+                raise RuntimeError(msg)
+        elif patch_file is not None:
+            # Upstream lockfile is now fresh — clear the patch so it's a no-op.
+            patch_file.write_text("")


### PR DESCRIPTION
## Summary

v3.17.0 ships a bun.lock still referencing 3.16.0 platform binaries. Add fix-stale-bun-lock.patch to correct it at build time.

Also update scripts/updater/bun.py to auto-generate this patch in future updates when pkg_dir is provided, instead of raising an error.

## Test plan

<!-- How did you test this change? -->

- [x] `nix build .#<package>` succeeds
- [ ] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work


