### PR TITLE
omp: resolve bun workspace catalog refs for 14.1.1

### DIFF
--- a/packages/omp/bun.nix
+++ b/packages/omp/bun.nix
@@ -38,9 +38,9 @@
     url = "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz";
     hash = "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==";
   };
-  "@aws-sdk/client-bedrock-runtime@3.1029.0" = fetchurl {
-    url = "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1029.0.tgz";
-    hash = "sha512-LFmNV+rLPXS87vdQBfNOmhlo+3T+t07tvyEmHeGec8jUAbOFckKbU7TTy7ePe9xVYOXQYcLw+pwslJ/VZvxDkw==";
+  "@aws-sdk/client-bedrock-runtime@3.1030.0" = fetchurl {
+    url = "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1030.0.tgz";
+    hash = "sha512-5Lnyx6mQPsIdld5Xr9FJqu8Hi9RVY6SgE8Rysmn4r3lRY2vNohNEu+gCtdXRDkkv/PgK9OnbA0sUPFU9rBRMYA==";
   };
   "@aws-sdk/core@3.973.27" = fetchurl {
     url = "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.27.tgz";
@@ -118,9 +118,9 @@
     url = "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1026.0.tgz";
     hash = "sha512-Ieq/HiRrbEtrYP387Nes0XlR7H1pJiJOZKv+QyQzMYpvTiDs0VKy2ZB3E2Zf+aFovWmeE7lRE4lXyF7dYM6GgA==";
   };
-  "@aws-sdk/token-providers@3.1029.0" = fetchurl {
-    url = "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1029.0.tgz";
-    hash = "sha512-oU3a9wEBUYHuWsoMpahiRIIQMUy2RSRb9NhlJ9DtKTwYWV2OXZ0hEM+RTjIC8T8I8v/C83OqbZrj7NBg1ATAhw==";
+  "@aws-sdk/token-providers@3.1030.0" = fetchurl {
+    url = "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1030.0.tgz";
+    hash = "sha512-gUuCLTnEiUgpxHEnJSidxZZlQ+rQwc/mrijz6DxeMijTwS3/e3UfJvL8C1YDvcbt8MkkXj92h0MpYtfhR+EGeg==";
   };
   "@aws-sdk/types@3.973.7" = fetchurl {
     url = "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.7.tgz";
@@ -266,9 +266,9 @@
     url = "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz";
     hash = "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==";
   };
-  "@google/genai@1.49.0" = fetchurl {
-    url = "https://registry.npmjs.org/@google/genai/-/genai-1.49.0.tgz";
-    hash = "sha512-hO69Zl0H3x+L0KL4stl1pLYgnqnwHoLqtKy6MRlNnW8TAxjqMdOUVafomKd4z1BePkzoxJWbYILny9a2Zk43VQ==";
+  "@google/genai@1.50.0" = fetchurl {
+    url = "https://registry.npmjs.org/@google/genai/-/genai-1.50.0.tgz";
+    hash = "sha512-oHv7JfdI6SLUitERptYoHqpn4Y2wWyPOBfWtpw8kfKTqqEiMJpUC6SEtiQPogb55Ip8fymj4bxGnGBTVV/Z9Ew==";
   };
   "@inquirer/ansi@2.0.5" = fetchurl {
     url = "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.5.tgz";
@@ -670,9 +670,9 @@
     url = "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz";
     hash = "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==";
   };
-  "@smithy/config-resolver@4.4.14" = fetchurl {
-    url = "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.14.tgz";
-    hash = "sha512-N55f8mPEccpzKetUagdvmAy8oohf0J5cuj9jLI1TaSceRlq0pJsIZepY3kmAXAhyxqXPV6hDerDQhqQPKWgAoQ==";
+  "@smithy/config-resolver@4.4.15" = fetchurl {
+    url = "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.15.tgz";
+    hash = "sha512-BJdMBY5YO9iHh+lPLYdHv6LbX+J8IcPCYMl1IJdBt2KDWNHwONHrPVHk3ttYBqJd9wxv84wlbN0f7GlQzcQtNQ==";
   };
   "@smithy/core@3.23.14" = fetchurl {
     url = "https://registry.npmjs.org/@smithy/core/-/core-3.23.14.tgz";
@@ -818,13 +818,13 @@
     url = "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.45.tgz";
     hash = "sha512-ag9sWc6/nWZAuK3Wm9KlFJUnRkXLrXn33RFjIAmCTFThqLHY+7wCst10BGq56FxslsDrjhSie46c8OULS+BiIw==";
   };
-  "@smithy/util-defaults-mode-node@4.2.49" = fetchurl {
-    url = "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.49.tgz";
-    hash = "sha512-jlN6vHwE8gY5AfiFBavtD3QtCX2f7lM3BKkz7nFKSNfFR5nXLXLg6sqXTJEEyDwtxbztIDBQCfjsGVXlIru2lQ==";
+  "@smithy/util-defaults-mode-node@4.2.50" = fetchurl {
+    url = "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.50.tgz";
+    hash = "sha512-xpjncL5XozFA3No7WypTsPU1du0fFS8flIyO+Wh2nhCy7bpEapvU7BR55Bg+wrfw+1cRA+8G8UsTjaxgzrMzXg==";
   };
-  "@smithy/util-endpoints@3.3.4" = fetchurl {
-    url = "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.3.4.tgz";
-    hash = "sha512-BKoR/ubPp9KNKFxPpg1J28N1+bgu8NGAtJblBP7yHy8yQPBWhIAv9+l92SlQLpolGm71CVO+btB60gTgzT0wog==";
+  "@smithy/util-endpoints@3.4.0" = fetchurl {
+    url = "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.4.0.tgz";
+    hash = "sha512-QQHGPKkw6NPcU6TJ1rNEEa201srPtZiX4k61xL163vvs9sTqW/XKz+UEuJ00uvPqoN+5Rs4Ka1UJ7+Mp03IXJw==";
   };
   "@smithy/util-hex-encoding@4.2.2" = fetchurl {
     url = "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz";
@@ -877,30 +877,6 @@
   "@tootallnate/quickjs-emscripten@0.23.0" = fetchurl {
     url = "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz";
     hash = "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==";
-  };
-  "@turbo/darwin-64@2.9.6" = fetchurl {
-    url = "https://registry.npmjs.org/@turbo/darwin-64/-/darwin-64-2.9.6.tgz";
-    hash = "sha512-X/56SnVXIQZBLKwniGTwEQTGmtE5brSACnKMBWpY3YafuxVYefrC2acamfjgxP7BG5w3I+6jf0UrLoSzgPcSJg==";
-  };
-  "@turbo/darwin-arm64@2.9.6" = fetchurl {
-    url = "https://registry.npmjs.org/@turbo/darwin-arm64/-/darwin-arm64-2.9.6.tgz";
-    hash = "sha512-aalBeSl4agT/QtYGDyf/XLajedWzUC9Vg/pm/YO6QQ93vkQ91Vz5uK1ta5RbVRDozQSz4njxUNqRNmOXDzW+qw==";
-  };
-  "@turbo/linux-64@2.9.6" = fetchurl {
-    url = "https://registry.npmjs.org/@turbo/linux-64/-/linux-64-2.9.6.tgz";
-    hash = "sha512-YKi05jnNHaD7vevgYwahpzGwbsNNTwzU2c7VZdmdFm7+cGDP4oREUWSsainiMfRqjRuolQxBwRn8wf1jmu+YZA==";
-  };
-  "@turbo/linux-arm64@2.9.6" = fetchurl {
-    url = "https://registry.npmjs.org/@turbo/linux-arm64/-/linux-arm64-2.9.6.tgz";
-    hash = "sha512-02o/ZS69cOYEDczXvOB2xmyrtzjQ2hVFtWZK1iqxXUfzMmTjZK4UumrfNnjckSg+gqeBfnPRHa0NstA173Ik3g==";
-  };
-  "@turbo/windows-64@2.9.6" = fetchurl {
-    url = "https://registry.npmjs.org/@turbo/windows-64/-/windows-64-2.9.6.tgz";
-    hash = "sha512-wVdQjvnBI15wB6JrA+43CtUtagjIMmX6XYO758oZHAsCNSxqRlJtdyujih0D8OCnwCRWiGWGI63zAxR0hO6s9g==";
-  };
-  "@turbo/windows-arm64@2.9.6" = fetchurl {
-    url = "https://registry.npmjs.org/@turbo/windows-arm64/-/windows-arm64-2.9.6.tgz";
-    hash = "sha512-1XUUyWW0W6FTSqGEhU8RHVqb2wP1SPkr7hIvBlMEwH9jr+sJQK5kqeosLJ/QaUv4ecSAd1ZhIrLoW7qslAzT4A==";
   };
   "@tybys/wasm-util@0.10.1" = fetchurl {
     url = "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz";
@@ -1398,9 +1374,9 @@
     url = "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz";
     hash = "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==";
   };
-  "fast-xml-parser@5.5.11" = fetchurl {
-    url = "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.11.tgz";
-    hash = "sha512-QL0eb0YbSTVWF6tTf1+LEMSgtCEjBYPpnAjoLC8SscESlAjXEIRJ7cHtLG0pLeDFaZLa4VKZLArtA/60ZS7vyA==";
+  "fast-xml-parser@5.5.12" = fetchurl {
+    url = "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.12.tgz";
+    hash = "sha512-nUR0q8PPfoA/svPM43Gup7vLOZWppaNrYgGmrVqrAVJa7cOH4hMG6FX9M4mQ8dZA1/ObGZHzES7Ed88hxEBSJg==";
   };
   "fast-xml-parser@5.5.8" = fetchurl {
     url = "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz";
@@ -1934,6 +1910,10 @@
     url = "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz";
     hash = "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==";
   };
+  "safe-buffer@5.2.1" = fetchurl {
+    url = "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz";
+    hash = "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==";
+  };
   "safe-stable-stringify@2.5.0" = fetchurl {
     url = "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz";
     hash = "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==";
@@ -2022,6 +2002,10 @@
     url = "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz";
     hash = "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==";
   };
+  "string_decoder@1.3.0" = fetchurl {
+    url = "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz";
+    hash = "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==";
+  };
   "strip-ansi@6.0.1" = fetchurl {
     url = "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz";
     hash = "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==";
@@ -2085,10 +2069,6 @@
   "tslib@2.8.1" = fetchurl {
     url = "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz";
     hash = "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==";
-  };
-  "turbo@2.9.6" = fetchurl {
-    url = "https://registry.npmjs.org/turbo/-/turbo-2.9.6.tgz";
-    hash = "sha512-+v2QJey7ZUeUiuigkU+uFfklvNUyPI2VO2vBpMYJA+a1hKFLFiKtUYlRHdb3P9CrAvMzi0upbjI4WT+zKtqkBg==";
   };
   "turndown-plugin-gfm@1.0.2" = fetchurl {
     url = "https://registry.npmjs.org/turndown-plugin-gfm/-/turndown-plugin-gfm-1.0.2.tgz";

--- a/packages/omp/hashes.json
+++ b/packages/omp/hashes.json
@@ -1,5 +1,5 @@
 {
-  "version": "14.1.0",
-  "hash": "sha256-XmmWRQwhQYaoz5kdySPhNHC0jt9fuofDNfRQEsq1e8U=",
-  "cargoHash": "sha256-raG0zLW3pICP3tsFKUUSZEzV8a1gy3j7/DVSzTsczjI="
+  "version": "14.1.1",
+  "hash": "sha256-BU77Jhu2MBp7Yx73t1/TOEgJIAvSB+Z3stC/arjNo9I=",
+  "cargoHash": "sha256-xw92JgMVsAQWEYgOLLZim37K6fz4iDTdco+myQvs5fU="
 }

--- a/packages/omp/package.nix
+++ b/packages/omp/package.nix
@@ -78,6 +78,75 @@ stdenv.mkDerivation {
   dontStrip = true;
 
   postPatch = ''
+    # Upstream (>=14.1.1) uses bun workspace "catalog:" references that
+    # point at versions declared in the root package.json. bun resolves
+    # these against the registry during `bun build --compile`, which is
+    # unavailable in the Nix sandbox. Inline the catalog entries so every
+    # package.json and bun.lock contains concrete version specifiers.
+    ${bun}/bin/bun run - <<'RESOLVE_CATALOG'
+    import { readFileSync, writeFileSync, readdirSync, statSync } from "node:fs";
+    import { join } from "node:path";
+
+    const root = JSON.parse(readFileSync("package.json", "utf8"));
+    const catalog = root.workspaces?.catalog ?? {};
+    if (root.workspaces && typeof root.workspaces === "object") {
+      delete root.workspaces.catalog;
+      if (Array.isArray(root.workspaces.packages)) {
+        root.workspaces = root.workspaces.packages;
+      }
+    }
+
+    const rewriteDeps = (deps) => {
+      if (!deps) return;
+      for (const [name, spec] of Object.entries(deps)) {
+        if (typeof spec === "string" && spec.startsWith("catalog")) {
+          const resolved = catalog[name];
+          if (!resolved) throw new Error(`catalog missing entry for ''${name}`);
+          deps[name] = resolved;
+        }
+      }
+    };
+
+    const rewritePkg = (path) => {
+      const pkg = JSON.parse(readFileSync(path, "utf8"));
+      for (const key of [
+        "dependencies",
+        "devDependencies",
+        "peerDependencies",
+        "optionalDependencies",
+      ]) {
+        rewriteDeps(pkg[key]);
+      }
+      writeFileSync(path, `''${JSON.stringify(pkg, null, 2)}\n`);
+    };
+
+    for (const key of [
+      "dependencies",
+      "devDependencies",
+      "peerDependencies",
+      "optionalDependencies",
+    ]) {
+      rewriteDeps(root[key]);
+    }
+    writeFileSync("package.json", `''${JSON.stringify(root, null, 2)}\n`);
+
+    for (const name of readdirSync("packages")) {
+      const p = join("packages", name, "package.json");
+      try { if (statSync(p).isFile()) rewritePkg(p); } catch {}
+    }
+
+    // Rewrite catalog refs in bun.lock too. bun.lock is JSONC-ish but the
+    // entries are simple quoted key/value pairs so a line-wise rewrite is
+    // sufficient and preserves the rest of the file verbatim.
+    let lock = readFileSync("bun.lock", "utf8");
+    lock = lock.replace(/"([^"\n]+)": "catalog:?"/g, (m, name) => {
+      const resolved = catalog[name];
+      if (!resolved) throw new Error(`catalog missing entry for ''${name} (bun.lock)`);
+      return `"''${name}": "''${resolved}"`;
+    });
+    writeFileSync("bun.lock", lock);
+    RESOLVE_CATALOG
+
     # bun resolves caret-range specifiers via the npm registry even when the
     # pinned version is already in the local cache. In the Nix sandbox this
     # fails because the network is blocked. Strip ^ and ~ prefixes so bun


### PR DESCRIPTION
Fixes the build for omp 14.1.1 (#3997).

Upstream introduced bun workspace `catalog:` references in root `package.json`. bun tries to resolve these against the npm registry at install/compile time, which fails in the Nix sandbox:

```
error: @anthropic-ai/sdk@catalog: failed to resolve
error: @biomejs/biome@catalog: failed to resolve
...
```

This patch adds a `postPatch` step that inlines every `catalog:` reference from the root `package.json` catalog into all workspace `package.json` files and `bun.lock` before bun runs, so no registry lookup is needed.

Verified with `nix build .#omp`; `omp --version` reports `omp/14.1.1`.