### PR TITLE
overlays: add shared-nixpkgs variant that builds against final

### DIFF
--- a/README.md
+++ b/README.md
@@ -940,7 +940,17 @@ Add to your system configuration:
 
 ### Using Overlay
 
-Alternatively, use the overlay to access packages under the `llm-agents` namespace:
+Alternatively, use an overlay to access packages under the `llm-agents`
+namespace. Two are provided:
+
+- `overlays.default` exposes `packages.${system}` as-is. Packages are built
+  against this flake's pinned nixpkgs, so the [binary cache](#binary-cache)
+  hits regardless of your nixpkgs revision, at the cost of evaluating a second
+  nixpkgs instance.
+- `overlays.shared-nixpkgs` rebuilds each package against **your** nixpkgs, so
+  dependencies are shared with the rest of your system and no extra nixpkgs is
+  evaluated. The binary cache will only hit when your nixpkgs revision matches
+  ours.
 
 ```nix
 {

--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1771437256,
-        "narHash": "sha256-bLqwib+rtyBRRVBWhMuBXPCL/OThfokA+j6+uH7jDGU=",
+        "lastModified": 1776249299,
+        "narHash": "sha256-Dt9t1TGRmJFc0xVYhttNBD6QsAgHOHCArqGa0AyjrJY=",
         "owner": "numtide",
         "repo": "blueprint",
-        "rev": "06ee7190dc2620ea98af9eb225aa9627b68b0e33",
+        "rev": "56131e8628f173d24a27f6d27c0215eff57e40dd",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -44,8 +44,13 @@
     in
     blueprintOutputs
     // {
-      overlays.default = import ./overlays {
-        packages = blueprintOutputs.packages;
+      overlays = {
+        default = import ./overlays {
+          inherit (blueprintOutputs) packages;
+        };
+        shared-nixpkgs = import ./overlays/shared-nixpkgs.nix {
+          inherit (blueprintOutputs) mkPackagesFor;
+        };
       };
     };
 }

--- a/overlays/shared-nixpkgs.nix
+++ b/overlays/shared-nixpkgs.nix
@@ -1,0 +1,10 @@
+{
+  mkPackagesFor,
+}:
+# Builds the packages/ tree against the consumer's `final`, so deps are
+# shared with the rest of their system and no second nixpkgs is
+# evaluated. Trade-off vs overlays.default: the binary cache only hits
+# when the consumer's nixpkgs revision matches ours.
+final: _prev: {
+  llm-agents = mkPackagesFor final;
+}


### PR DESCRIPTION
`overlays.default` hands back `packages.${system}` as-is, so applying it pulls this flake's own nixpkgs instantiation (`import inputs.nixpkgs { config.allowUnfree = true; }` via blueprint) into the consumer's eval.
`inputs.nixpkgs.follows` doesn't avoid that — it only changes which source gets re-imported, but still imports a second instance.

This adds `overlays.shared-nixpkgs`, which uses blueprint's new `mkPackagesFor` (numtide/blueprint#150) to rebuild the `packages/` tree against the consumer's `final`.
Dependencies are shared with the rest of their system and only one nixpkgs is evaluated.
Measured on a NixOS config that consumes `pi`/`tuicr`/`rtk`/`openspec` via the overlay: ~0.5M fewer function calls out of ~20M (~2.5%).
`overlays.default` is left unchanged for users who want cache hits independent of their nixpkgs pin.

The blueprint input is bumped to pick up `mkPackagesFor`; `packages.${system}` drv hashes are unchanged by the bump.

Fixes #1172.
