### PR TITLE
skills: init at 1.5.0

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -92,6 +92,11 @@ inputs.nixpkgs.lib.extend (
         githubId = 105790745;
         name = "Sergii Maksymov";
       };
+      kusold = {
+        github = "kusold";
+        githubId = 509966;
+        name = "Mike Kusold";
+      };
     };
   }
 )

--- a/packages/skills/default.nix
+++ b/packages/skills/default.nix
@@ -1,0 +1,1 @@
+{ pkgs, flake }: pkgs.callPackage ./package.nix { inherit flake; }

--- a/packages/skills/package.nix
+++ b/packages/skills/package.nix
@@ -4,6 +4,7 @@
   fetchzip,
   makeWrapper,
   nodejs,
+  versionCheckHook,
   flake,
 }:
 
@@ -23,6 +24,8 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ makeWrapper ];
+  # nodejs in buildInputs (not nativeBuildInputs) so the fixup-phase
+  # patchShebangs --host rewrite of bin/cli.mjs resolves to the runtime node.
   buildInputs = [ nodejs ];
 
   installPhase = ''
@@ -44,12 +47,7 @@ stdenv.mkDerivation rec {
   '';
 
   doInstallCheck = true;
-  nativeInstallCheckInputs = [ nodejs ];
-  installCheckPhase = ''
-    runHook preInstallCheck
-    $out/bin/skills --help 2>&1 | grep -qi "skill"
-    runHook postInstallCheck
-  '';
+  nativeInstallCheckInputs = [ versionCheckHook ];
 
   passthru.category = "Claude Code Ecosystem";
 
@@ -58,7 +56,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/vercel-labs/skills";
     changelog = "https://github.com/vercel-labs/skills/releases/tag/v${version}";
     license = licenses.mit;
-    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
     maintainers = with flake.lib.maintainers; [ ];
     mainProgram = "skills";
     platforms = platforms.all;

--- a/packages/skills/package.nix
+++ b/packages/skills/package.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  stdenv,
+  fetchzip,
+  makeWrapper,
+  nodejs,
+  flake,
+}:
+
+let
+  yaml = fetchzip {
+    url = "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz";
+    hash = "sha256-sslihpXhi8dVxXJ8svHg4lpKGdGL74Oqqs5J/P/jvDg=";
+  };
+in
+stdenv.mkDerivation rec {
+  pname = "skills";
+  version = "1.5.0";
+
+  src = fetchzip {
+    url = "https://registry.npmjs.org/${pname}/-/${pname}-${version}.tgz";
+    hash = "sha256-FWmQof42nLo8+w3UQBaalcJ4sAMRoZqeFnvuSe5yroI=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ nodejs ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/libexec/skills/node_modules/yaml
+    cp -r ${yaml}/* $out/libexec/skills/node_modules/yaml/
+
+    cp -r bin dist package.json $out/libexec/skills/
+
+    mkdir -p $out/bin
+    makeWrapper $out/libexec/skills/bin/cli.mjs $out/bin/skills \
+      --prefix PATH : ${lib.makeBinPath [ nodejs ]}
+
+    ln -s $out/bin/skills $out/bin/add-skill
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ nodejs ];
+  installCheckPhase = ''
+    runHook preInstallCheck
+    $out/bin/skills --help 2>&1 | grep -qi "skill"
+    runHook postInstallCheck
+  '';
+
+  passthru.category = "Claude Code Ecosystem";
+
+  meta = with lib; {
+    description = "The open agent skills tool for installing and managing skills across AI coding agents";
+    homepage = "https://github.com/vercel-labs/skills";
+    changelog = "https://github.com/vercel-labs/skills/releases/tag/v${version}";
+    license = licenses.mit;
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
+    maintainers = with flake.lib.maintainers; [ ];
+    mainProgram = "skills";
+    platforms = platforms.all;
+  };
+}

--- a/packages/skills/package.nix
+++ b/packages/skills/package.nix
@@ -35,7 +35,8 @@ stdenv.mkDerivation rec {
 
     mkdir -p $out/bin
     makeWrapper $out/libexec/skills/bin/cli.mjs $out/bin/skills \
-      --prefix PATH : ${lib.makeBinPath [ nodejs ]}
+      --prefix PATH : ${lib.makeBinPath [ nodejs ]} \
+      --set DISABLE_TELEMETRY 1
 
     ln -s $out/bin/skills $out/bin/add-skill
 

--- a/packages/skills/package.nix
+++ b/packages/skills/package.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
     changelog = "https://github.com/vercel-labs/skills/releases/tag/v${version}";
     license = licenses.mit;
     sourceProvenance = with lib.sourceTypes; [ fromSource ];
-    maintainers = with flake.lib.maintainers; [ ];
+    maintainers = with flake.lib.maintainers; [ kusold ];
     mainProgram = "skills";
     platforms = platforms.all;
   };


### PR DESCRIPTION
## Summary

- Package [vercel-labs/skills](https://github.com/vercel-labs/skills) — the open agent skills CLI for installing and managing skills across 40+ AI coding agents (Claude Code, Codex, Cursor, Gemini CLI, etc.)
- Fetches pre-built npm tarball with bundled deps; only `yaml` is installed as a runtime node_modules dependency
- Provides both `skills` and `add-skill` binaries (matching upstream npm `bin` config)

## Test plan

- [x] `nix build .#skills` succeeds
- [x] `nix fmt` — no changes needed
- [x] `./result/bin/skills --version` reports `1.5.0`
- [x] `./result/bin/skills --help` shows usage
- [x] `./result/bin/add-skill --help` works (symlink alias)