### PR TITLE
pi: disable telemetry

### DIFF
--- a/packages/pi/package.nix
+++ b/packages/pi/package.nix
@@ -52,7 +52,8 @@ buildNpmPackage {
           ripgrep
         ]
       } \
-      --set PI_SKIP_VERSION_CHECK 1
+      --set PI_SKIP_VERSION_CHECK 1 \
+      --set PI_TELEMETRY 0
   '';
 
   doInstallCheck = true;


### PR DESCRIPTION
pi sends telemetry since v0.67.1

https://github.com/badlogic/pi-mono/releases/tag/v0.67.1