### PR TITLE
git-surgeon: init at 0.1.14

### DIFF
--- a/packages/git-surgeon/default.nix
+++ b/packages/git-surgeon/default.nix
@@ -1,0 +1,1 @@
+{ pkgs, ... }: pkgs.callPackage ./package.nix { }

--- a/packages/git-surgeon/package.nix
+++ b/packages/git-surgeon/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "git-surgeon";
+  version = "0.1.14";
+
+  src = fetchFromGitHub {
+    owner = "raine";
+    repo = "git-surgeon";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-5Ac4pdxB8FJbGGNc+gi+E+KHQgur3DTeF1IpboYdQJA=";
+  };
+
+  cargoHash = "sha256-PdywtdBMwCRNoiUUNmfE/yATI0snWHrhJJVW0sMpUAc=";
+
+  postInstall = ''
+    install -d $out/share/git-surgeon
+    cp -r skills $out/share/git-surgeon/skills
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.category = "Utilities";
+
+  meta = {
+    description = "Git primitives for autonomous coding agents";
+    longDescription = ''
+      git-surgeon gives AI agents surgical control over git changes without
+      interactive prompts. Stage, unstage, or discard individual hunks. Commit
+      hunks directly with line-range precision. Restructure history by
+      splitting commits or folding fixes into earlier ones.
+    '';
+    homepage = "https://github.com/raine/git-surgeon";
+    changelog = "https://github.com/raine/git-surgeon/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    mainProgram = "git-surgeon";
+    maintainers = with lib.maintainers; [ sei40kr ];
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
## Summary

- Adds [git-surgeon](https://github.com/raine/git-surgeon) v0.1.14 — non-interactive hunk-level git staging for AI agents, letting them stage, unstage, commit, split, fixup, or discard individual hunks without `git add -p`.
- Packaged via `rustPlatform.buildRustPackage`, placed in the **Utilities** category, with `versionCheckHook` and inline version/hash for `nix-update` compatibility.
- Agent skill (`skills/git-surgeon/SKILL.md`) is embedded in the binary via `include_str!`; users install it on demand with `git-surgeon install-skill --claude|--opencode|--codex`.

## Test plan

- [x] `nix build .#git-surgeon` succeeds on x86_64-linux
- [x] `nix build .#checks.x86_64-linux.pkgs-git-surgeon` passes (versionCheckHook reports `git-surgeon 0.1.14`)
- [x] `nix fmt` is clean
- [x] `./scripts/generate-package-docs.py` regenerated (README entry added)
- [x] `nix-update --flake git-surgeon` correctly bumps version + hashes (tested by downgrading to 0.1.13 and updating back)

🤖 Generated with [Claude Code](https://claude.com/claude-code)