### PR TITLE
zeroclaw: refresh src hash after upstream retag of v0.7.3

### DIFF
--- a/packages/zeroclaw/package.nix
+++ b/packages/zeroclaw/package.nix
@@ -19,7 +19,7 @@ let
     owner = "zeroclaw-labs";
     repo = "zeroclaw";
     tag = "v${version}";
-    hash = "sha256-eIfHjBHE5po0RjJcrfQiJOUW+HbVuizVpKdVBcLyQRg=";
+    hash = "sha256-Lr30nJ2IRAZzxS8Dc43c5mj3ab2suVbZxLTLx0mBRF0=";
   };
 
   frontendSrc = runCommand "${pname}-web-src-${version}" { } ''


### PR DESCRIPTION

Upstream force-moved the v0.7.3 tag roughly ten minutes after we merged
the bump, landing a CI token fix (#5894) on top and changing the GitHub
archive contents. Anyone without the original FOD in their store now
hits a hash mismatch.

The retag only touched release workflow files, so the Cargo.lock and
web/package-lock.json are unchanged and the cargoHash/npmDeps hashes
stay valid.

Fixes #4126.


