### PR TITLE
feat: add code-review-graph package

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -97,6 +97,11 @@ inputs.nixpkgs.lib.extend (
         githubId = 17411645;
         name = "Shinya Uemura";
       };
+      aldoborrero = {
+        github = "aldoborrero";
+        githubId = 82811;
+        name = "Aldo Borrero";
+      };
     };
   }
 )

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -97,11 +97,6 @@ inputs.nixpkgs.lib.extend (
         githubId = 17411645;
         name = "Shinya Uemura";
       };
-      aldoborrero = {
-        github = "aldoborrero";
-        githubId = 82811;
-        name = "Aldo Borrero";
-      };
     };
   }
 )

--- a/packages/code-review-graph/default.nix
+++ b/packages/code-review-graph/default.nix
@@ -1,0 +1,5 @@
+{
+  pkgs,
+  ...
+}:
+pkgs.callPackage ./package.nix { }

--- a/packages/code-review-graph/package.nix
+++ b/packages/code-review-graph/package.nix
@@ -41,7 +41,7 @@ python3.pkgs.buildPythonApplication rec {
 
   pythonImportsCheck = [ "code_review_graph" ];
 
-  passthru.category = "Developer Tools";
+  passthru.category = "Code Review";
 
   meta = with lib; {
     description = "Local knowledge graph for AI coding agents — builds persistent map of your codebase for token-efficient code reviews";
@@ -49,8 +49,10 @@ python3.pkgs.buildPythonApplication rec {
     changelog = "https://github.com/tirth8205/code-review-graph/releases/tag/v${version}";
     license = licenses.mit;
     sourceProvenance = with sourceTypes; [ fromSource ];
-    maintainers = with lib; [ maintainers.aldoborrero ];
-    platforms = platforms.linux;
+    maintainers = with maintainers; [ aldoborrero ];
+    # Transitive dependency `lupa` ships a pre-built LuaJIT that only links
+    # on x86_64, so we exclude aarch64-linux.
+    platforms = [ "x86_64-linux" ];
     mainProgram = "code-review-graph";
   };
 }

--- a/packages/code-review-graph/package.nix
+++ b/packages/code-review-graph/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "code-review-graph";
+  version = "2.3.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "tirth8205";
+    repo = "code-review-graph";
+    rev = "v${version}";
+    hash = "sha256-2U+NfPOb2A/gmqzRUQ/80C5EhOHPM4YpGilZmVSTY/g=";
+  };
+
+  build-system = with python3.pkgs; [
+    hatchling
+  ];
+
+  # Upstream pins tree-sitter-language-pack <1 and watchdog <6, but nixpkgs
+  # has advanced to 1.x and 6.x. The runtime deps check is overly strict.
+  pypaBuildFlags = [ "--skip-dependency-check" ];
+
+  dependencies = with python3.pkgs; [
+    mcp
+    fastmcp
+    tree-sitter
+    tree-sitter-language-pack
+    networkx
+    watchdog
+  ];
+
+  # Relax version constraints — nixpkgs versions are newer but compatible.
+  pythonRelaxDeps = [
+    "tree-sitter-language-pack"
+    "watchdog"
+  ];
+
+  pythonImportsCheck = [ "code_review_graph" ];
+
+  passthru.category = "Developer Tools";
+
+  meta = with lib; {
+    description = "Local knowledge graph for AI coding agents — builds persistent map of your codebase for token-efficient code reviews";
+    homepage = "https://github.com/tirth8205/code-review-graph";
+    changelog = "https://github.com/tirth8205/code-review-graph/releases/tag/v${version}";
+    license = licenses.mit;
+    sourceProvenance = with sourceTypes; [ fromSource ];
+    maintainers = with lib; [ maintainers.aldoborrero ];
+    platforms = platforms.linux;
+    mainProgram = "code-review-graph";
+  };
+}


### PR DESCRIPTION
## Summary

Add [code-review-graph](https://github.com/tirth8205/code-review-graph) v2.3.2 — a local knowledge graph for AI coding agents.

It builds a structural map of your codebase with Tree-sitter and exposes it via MCP, enabling token-efficient code reviews by letting AI assistants read only what matters.

## Features

- 23+ languages with Tree-sitter parsing
- Incremental updates (<2s)
- Blast-radius analysis for changed files
- 28 MCP tools for graph queries, semantic search, and code review
- CLI command: `code-review-graph`

## Package details

- **Source**: GitHub (`tirth8205/code-review-graph`)
- **Version**: 2.3.2
- **Build system**: hatchling
- **Maintainer**: aldoborrero

### Nix-specific notes

- `pypaBuildFlags = ["--skip-dependency-check"]` — skips overly strict build-time deps check
- `pythonRelaxDeps` — relaxes upstreams `<1` / `<6` upper bounds for `tree-sitter-language-pack` and `watchdog` (nixpkgs has 1.4.1 / 6.0.0 which are compatible)

## Verification

- `nix build .#code-review-graph` ✅
- `nix fmt` ✅
- `nix flake check` ✅
- `code-review-graph --version` → `code-review-graph 2.3.2` ✅