### PR TITLE
oh-my-claudecode: init at 4.13.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>oh-my-claudecode</strong> - Multi-agent orchestration system for Claude Code</summary>
+
+- **Source**: source
+- **License**: MIT
+- **Homepage**: https://github.com/yeachan-heo/oh-my-claudecode
+- **Usage**: `nix run github:numtide/llm-agents.nix#oh-my-claudecode -- --help`
+- **Nix**: [packages/oh-my-claudecode/package.nix](packages/oh-my-claudecode/package.nix)
+
+</details>
+<details>
 <summary><strong>sandbox-runtime</strong> - Lightweight sandboxing tool for enforcing filesystem and network restrictions</summary>
 
 - **Source**: source

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -97,6 +97,11 @@ inputs.nixpkgs.lib.extend (
         githubId = 17411645;
         name = "Shinya Uemura";
       };
+      murlakatam = {
+        github = "murlakatam";
+        githubId = 38276;
+        name = "Eugene Baranovsky";
+      };
     };
   }
 )

--- a/packages/oh-my-claudecode/default.nix
+++ b/packages/oh-my-claudecode/default.nix
@@ -1,0 +1,8 @@
+{ pkgs, flake, ... }:
+let
+  npmPackumentSupport = pkgs.callPackage ../../lib/fetch-npm-deps.nix { };
+in
+pkgs.callPackage ./package.nix {
+  inherit flake;
+  inherit (npmPackumentSupport) fetchNpmDepsWithPackuments npmConfigHook;
+}

--- a/packages/oh-my-claudecode/package.nix
+++ b/packages/oh-my-claudecode/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  flake,
+  fetchNpmDepsWithPackuments,
+  npmConfigHook,
+  versionCheckHook,
+}:
+
+buildNpmPackage (finalAttrs: {
+  inherit npmConfigHook;
+  pname = "oh-my-claudecode";
+  version = "4.13.1";
+
+  src = fetchFromGitHub {
+    owner = "yeachan-heo";
+    repo = "oh-my-claudecode";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-C/m8Vlt6MXy8nlgqtoey9A5JnVTHCPkGUjar9x5Y2uw=";
+  };
+
+  npmDeps = fetchNpmDepsWithPackuments {
+    inherit (finalAttrs) src;
+    name = "${finalAttrs.pname}-${finalAttrs.version}-npm-deps";
+    hash = "sha256-XeyJSt1J0dGHZMb5Rzb8zPqoNTyy0GOj8J/cnbgSAfw=";
+    fetcherVersion = 2;
+  };
+  makeCacheWritable = true;
+
+  # Native deps (better-sqlite3, @ast-grep/napi) need rebuild skipped
+  npmFlags = [ "--ignore-scripts" ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.category = "Claude Code Ecosystem";
+
+  meta = {
+    description = "Multi-agent orchestration system for Claude Code";
+    homepage = "https://github.com/yeachan-heo/oh-my-claudecode";
+    changelog = "https://github.com/yeachan-heo/oh-my-claudecode/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    maintainers = with flake.lib.maintainers; [ murlakatam ];
+    mainProgram = "oh-my-claudecode";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
## Summary
- Add [oh-my-claudecode](https://github.com/yeachan-heo/oh-my-claudecode) — multi-agent orchestration system for Claude Code
- Version 4.13.1, built from source via `buildNpmPackage`
- Category: Claude Code Ecosystem

## Test plan
- [x] `nix build .#oh-my-claudecode` succeeds
- [x] `oh-my-claudecode --version` reports `4.13.1`
- [x] `oh-my-claudecode --help` shows CLI commands
- [x] `nix fmt` passes with no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)