### PR TITLE
context-hub: init at 0.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -803,6 +803,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>context-hub</strong> - CLI for Context Hub - search and retrieve LLM-optimized docs and skills</summary>
+
+- **Source**: source
+- **License**: MIT
+- **Homepage**: https://github.com/andrewyng/context-hub
+- **Usage**: `nix run github:numtide/llm-agents.nix#context-hub -- --help`
+- **Nix**: [packages/context-hub/package.nix](packages/context-hub/package.nix)
+
+</details>
+<details>
 <summary><strong>copilot-language-server</strong> - GitHub Copilot Language Server - AI pair programmer LSP</summary>
 
 - **Source**: bytecode

--- a/packages/context-hub/default.nix
+++ b/packages/context-hub/default.nix
@@ -1,8 +1,10 @@
-{ pkgs, flake, ... }:
-let
-  npmPackumentSupport = pkgs.callPackage ../../lib/fetch-npm-deps.nix { };
-in
+{
+  pkgs,
+  flake,
+  perSystem,
+  ...
+}:
 pkgs.callPackage ./package.nix {
   inherit flake;
-  inherit (npmPackumentSupport) fetchNpmDepsWithPackuments npmConfigHook;
+  inherit (perSystem.self) buildNpmPackage;
 }

--- a/packages/context-hub/default.nix
+++ b/packages/context-hub/default.nix
@@ -1,0 +1,8 @@
+{ pkgs, flake, ... }:
+let
+  npmPackumentSupport = pkgs.callPackage ../../lib/fetch-npm-deps.nix { };
+in
+pkgs.callPackage ./package.nix {
+  inherit flake;
+  inherit (npmPackumentSupport) fetchNpmDepsWithPackuments npmConfigHook;
+}

--- a/packages/context-hub/hashes.json
+++ b/packages/context-hub/hashes.json
@@ -1,0 +1,6 @@
+{
+  "version": "0.1.3",
+  "rev": "eeb895b03ed9a60a149fb9195313fc7280989c8c",
+  "hash": "sha256-373+s3OepXBg8q7vbKXDaxyobApUitlZuGwbCRhFu6Y=",
+  "npmDepsHash": "sha256-6aejmBVNztS8kAX9eq9HwfPJK6DwOCD3X6rQ5ZMQAmM="
+}

--- a/packages/context-hub/package.nix
+++ b/packages/context-hub/package.nix
@@ -3,16 +3,14 @@
   buildNpmPackage,
   fetchFromGitHub,
   flake,
-  fetchNpmDepsWithPackuments,
-  npmConfigHook,
   versionCheckHook,
 }:
 
 let
   versionData = lib.importJSON ./hashes.json;
 in
-buildNpmPackage (finalAttrs: {
-  inherit npmConfigHook;
+buildNpmPackage {
+  npmDepsFetcherVersion = 2;
   pname = "context-hub";
   inherit (versionData) version;
 
@@ -23,12 +21,7 @@ buildNpmPackage (finalAttrs: {
     inherit (versionData) rev hash;
   };
 
-  npmDeps = fetchNpmDepsWithPackuments {
-    inherit (finalAttrs) src;
-    name = "${finalAttrs.pname}-${finalAttrs.version}-npm-deps";
-    hash = versionData.npmDepsHash;
-    fetcherVersion = 2;
-  };
+  inherit (versionData) npmDepsHash;
   makeCacheWritable = true;
 
   dontNpmBuild = true;
@@ -65,4 +58,4 @@ buildNpmPackage (finalAttrs: {
     mainProgram = "chub";
     platforms = lib.platforms.all;
   };
-})
+}

--- a/packages/context-hub/package.nix
+++ b/packages/context-hub/package.nix
@@ -5,6 +5,7 @@
   flake,
   fetchNpmDepsWithPackuments,
   npmConfigHook,
+  versionCheckHook,
 }:
 
 buildNpmPackage (finalAttrs: {
@@ -15,6 +16,7 @@ buildNpmPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "andrewyng";
     repo = "context-hub";
+    # upstream does not tag releases; rev corresponds to cli/package.json v${version}
     rev = "596506ebb4d53cfbc6ae458b731e0b1a18790f9e";
     hash = "sha256-ozn5yrdtoPqcw/PiHJLHXT4Ayyed1AS1zak5a83pIQA=";
   };
@@ -32,8 +34,11 @@ buildNpmPackage (finalAttrs: {
   installPhase = ''
     runHook preInstall
 
+    npm prune --omit=dev --no-audit --no-fund
+
     mkdir -p $out/lib/context-hub $out/bin
-    cp -r cli node_modules package.json package-lock.json $out/lib/context-hub/
+    cp -r cli node_modules package.json $out/lib/context-hub/
+    rm -rf $out/lib/context-hub/cli/{test,tests}
 
     patchShebangs $out/lib/context-hub/cli/bin/
 
@@ -43,12 +48,15 @@ buildNpmPackage (finalAttrs: {
     runHook postInstall
   '';
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--cli-version";
+  doInstallCheck = true;
+
   passthru.category = "Utilities";
 
   meta = {
     description = "CLI for Context Hub - search and retrieve LLM-optimized docs and skills";
     homepage = "https://github.com/andrewyng/context-hub";
-    changelog = "https://github.com/andrewyng/context-hub/releases";
     license = lib.licenses.mit;
     sourceProvenance = with lib.sourceTypes; [ fromSource ];
     maintainers = with flake.lib.maintainers; [ murlakatam ];

--- a/packages/context-hub/package.nix
+++ b/packages/context-hub/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  flake,
+  fetchNpmDepsWithPackuments,
+  npmConfigHook,
+}:
+
+buildNpmPackage (finalAttrs: {
+  inherit npmConfigHook;
+  pname = "context-hub";
+  version = "0.1.3";
+
+  src = fetchFromGitHub {
+    owner = "andrewyng";
+    repo = "context-hub";
+    rev = "596506ebb4d53cfbc6ae458b731e0b1a18790f9e";
+    hash = "sha256-ozn5yrdtoPqcw/PiHJLHXT4Ayyed1AS1zak5a83pIQA=";
+  };
+
+  npmDeps = fetchNpmDepsWithPackuments {
+    inherit (finalAttrs) src;
+    name = "${finalAttrs.pname}-${finalAttrs.version}-npm-deps";
+    hash = "sha256-6aejmBVNztS8kAX9eq9HwfPJK6DwOCD3X6rQ5ZMQAmM=";
+    fetcherVersion = 2;
+  };
+  makeCacheWritable = true;
+
+  dontNpmBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/context-hub $out/bin
+    cp -r cli node_modules package.json package-lock.json $out/lib/context-hub/
+
+    patchShebangs $out/lib/context-hub/cli/bin/
+
+    ln -s $out/lib/context-hub/cli/bin/chub $out/bin/chub
+    ln -s $out/lib/context-hub/cli/bin/chub-mcp $out/bin/chub-mcp
+
+    runHook postInstall
+  '';
+
+  passthru.category = "Utilities";
+
+  meta = {
+    description = "CLI for Context Hub - search and retrieve LLM-optimized docs and skills";
+    homepage = "https://github.com/andrewyng/context-hub";
+    changelog = "https://github.com/andrewyng/context-hub/releases";
+    license = lib.licenses.mit;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    maintainers = with flake.lib.maintainers; [ murlakatam ];
+    mainProgram = "chub";
+    platforms = lib.platforms.all;
+  };
+})

--- a/packages/context-hub/package.nix
+++ b/packages/context-hub/package.nix
@@ -8,23 +8,25 @@
   versionCheckHook,
 }:
 
+let
+  versionData = lib.importJSON ./hashes.json;
+in
 buildNpmPackage (finalAttrs: {
   inherit npmConfigHook;
   pname = "context-hub";
-  version = "0.1.3";
+  inherit (versionData) version;
 
   src = fetchFromGitHub {
     owner = "andrewyng";
     repo = "context-hub";
-    # upstream does not tag releases; rev corresponds to cli/package.json v${version}
-    rev = "596506ebb4d53cfbc6ae458b731e0b1a18790f9e";
-    hash = "sha256-ozn5yrdtoPqcw/PiHJLHXT4Ayyed1AS1zak5a83pIQA=";
+    # upstream does not tag releases; rev/version maintained by update.py
+    inherit (versionData) rev hash;
   };
 
   npmDeps = fetchNpmDepsWithPackuments {
     inherit (finalAttrs) src;
     name = "${finalAttrs.pname}-${finalAttrs.version}-npm-deps";
-    hash = "sha256-6aejmBVNztS8kAX9eq9HwfPJK6DwOCD3X6rQ5ZMQAmM=";
+    hash = versionData.npmDepsHash;
     fetcherVersion = 2;
   };
   makeCacheWritable = true;

--- a/packages/context-hub/update.py
+++ b/packages/context-hub/update.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env nix
+#! nix shell --inputs-from .# nixpkgs#python3 --command python3
+
+"""Update script for context-hub package.
+
+Upstream does not tag releases.  We track the default branch HEAD and
+take the version from cli/package.json at that commit, so the derivation
+version stays meaningful while the rev pins a reproducible source.
+"""
+
+import sys
+from pathlib import Path
+from typing import cast
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+
+from updater import (
+    calculate_dependency_hash,
+    calculate_url_hash,
+    fetch_json,
+    load_hashes,
+    save_hashes,
+)
+from updater.hash import DUMMY_SHA256_HASH
+from updater.nix import NixCommandError
+
+PKG_DIR = Path(__file__).parent
+HASHES_FILE = PKG_DIR / "hashes.json"
+
+OWNER = "andrewyng"
+REPO = "context-hub"
+BRANCH = "main"
+
+
+def main() -> None:
+    """Update the context-hub package."""
+    data = load_hashes(HASHES_FILE)
+    current_rev = data["rev"]
+
+    head = cast(
+        "dict[str, str]",
+        fetch_json(f"https://api.github.com/repos/{OWNER}/{REPO}/commits/{BRANCH}"),
+    )
+    rev = head["sha"]
+
+    print(f"Current rev: {current_rev[:12]}, Latest rev: {rev[:12]}")
+
+    if rev == current_rev:
+        print("Already up to date")
+        return
+
+    pkg_json = cast(
+        "dict[str, str]",
+        fetch_json(
+            f"https://raw.githubusercontent.com/{OWNER}/{REPO}/{rev}/cli/package.json"
+        ),
+    )
+    version = pkg_json["version"]
+
+    print(
+        f"Updating context-hub: {data['version']} ({current_rev[:12]}) -> {version} ({rev[:12]})"
+    )
+
+    print("Calculating source hash...")
+    url = f"https://github.com/{OWNER}/{REPO}/archive/{rev}.tar.gz"
+    source_hash = calculate_url_hash(url, unpack=True)
+
+    data = {
+        "version": version,
+        "rev": rev,
+        "hash": source_hash,
+        "npmDepsHash": DUMMY_SHA256_HASH,
+    }
+    save_hashes(HASHES_FILE, data)
+
+    try:
+        npm_deps_hash = calculate_dependency_hash(
+            ".#context-hub", "npmDepsHash", HASHES_FILE, data
+        )
+        data["npmDepsHash"] = npm_deps_hash
+        save_hashes(HASHES_FILE, data)
+    except (ValueError, NixCommandError) as e:
+        print(f"Error: {e}")
+        return
+
+    print(f"Updated context-hub to {version} ({rev[:12]})")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add [context-hub](https://github.com/andrewyng/context-hub) (`chub`) — CLI for searching and retrieving LLM-optimized docs and skills
- Version 0.1.3, built from source via `buildNpmPackage` (npm workspace monorepo)
- Provides `chub` CLI and `chub-mcp` MCP server
- Category: Utilities
- Pairs well with oh-my-claudecode and oh-my-opencode for AI agent doc/skill retrieval

## Test plan
- [x] `nix build .#context-hub` succeeds
- [x] `chub --help` shows CLI commands
- [x] `chub --cli-version` reports `0.1.3`
- [x] `chub-mcp` MCP server starts correctly
- [x] `nix fmt` passes with no changes
- [x] README regenerated via `generate-package-docs.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)