### PR TITLE
ci: align update schedule with US release windows and Berlin off-hours

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,8 +1,10 @@
 name: Update Dependencies
 on:
   schedule:
-    # Run twice daily at 2 AM and 2 PM UTC
-    - cron: '0 2,14 * * *'
+    # 4x daily, outside Europe/Berlin work hours, tracking US West Coast release window.
+    # 18:00/21:00 UTC catch US morning/early-afternoon drops (evening in Berlin).
+    # 00:00/04:00 UTC sweep US end-of-day; results ready before Berlin morning.
+    - cron: '0 0,4,18,21 * * *'
   workflow_dispatch:
     inputs:
       packages:


### PR DESCRIPTION

The previous 02:00/14:00 UTC slots ran during the European workday and
before most US-based agent vendors ship their daily releases, so version
bumps either interrupted active work or arrived a cycle late.

Move to four runs at 18:00, 21:00, 00:00 and 04:00 UTC. These cover the
US West Coast business day where Anthropic, OpenAI and similar vendors
publish, while keeping every run outside Berlin working hours. The final
04:00 UTC sweep ensures any breakage is surfaced and waiting by the
start of the European morning rather than mid-afternoon.


