### PR TITLE
hermes-agent: ship optional messaging/gateway extras

### DIFF
--- a/packages/hermes-agent/package.nix
+++ b/packages/hermes-agent/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   flake,
   python3,
   fetchFromGitHub,
@@ -136,34 +137,90 @@ python3.pkgs.buildPythonApplication rec {
     setuptools
   ];
 
-  dependencies = with python3.pkgs; [
-    # Core
-    openai
-    anthropic
-    python-dotenv
-    fire
-    httpx
-    rich
-    tenacity
-    pyyaml
-    requests
-    jinja2
-    pydantic
-    # Interactive CLI
-    prompt-toolkit
-    # MCP
-    mcp
-    # Tools
-    exa-py
-    firecrawl-py
-    parallel-web
-    fal-client
-    # Text-to-speech
-    edge-tts
-    faster-whisper
-    # Skills Hub
-    pyjwt
-  ];
+  dependencies =
+    with python3.pkgs;
+    [
+      # Core
+      openai
+      anthropic
+      python-dotenv
+      fire
+      httpx
+      rich
+      tenacity
+      pyyaml
+      requests
+      jinja2
+      pydantic
+      # Interactive CLI
+      prompt-toolkit
+      # MCP
+      mcp
+      # Tools
+      exa-py
+      firecrawl-py
+      parallel-web
+      fal-client
+      # Text-to-speech
+      edge-tts
+      faster-whisper
+      # Skills Hub
+      pyjwt
+    ]
+    ++ optional-dependencies.gateway
+    ++ optional-dependencies.misc;
+
+  # Upstream ships most integrations as setuptools extras and degrades
+  # "gracefully" at runtime by logging a warning and refusing to start the
+  # adapter (see #4175 for the slack-bolt case). In a Nix closure the user
+  # cannot `pip install hermes-agent[slack]`, so pull in every extra that is
+  # already packaged in nixpkgs. Extras whose deps are not yet in nixpkgs
+  # (honcho, daytona, dingtalk, feishu) are intentionally omitted.
+  optional-dependencies = with python3.pkgs; {
+    # Everything the `hermes gateway` command can use.
+    gateway = [
+      # [messaging] / [slack]
+      slack-bolt
+      slack-sdk
+      python-telegram-bot
+      discordpy
+      aiohttp # also covers [homeassistant] and [sms]
+      # [cron]
+      croniter
+      # [web]
+      fastapi
+      uvicorn
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      # [matrix] — upstream gates this on linux because python-olm is
+      # broken on modern macOS toolchains.
+      mautrix
+      markdown
+      aiosqlite
+      asyncpg
+    ];
+    # Non-gateway extras kept separate so the test closure can stay slim if
+    # someone later wants `hermes-agent.override { withExtras = false; }`.
+    misc = [
+      # [cli]
+      simple-term-menu
+      # [pty]
+      ptyprocess
+      # [acp]
+      agent-client-protocol
+      # [voice] (faster-whisper already in core deps above)
+      sounddevice
+      numpy
+      # [tts-premium]
+      elevenlabs
+      # [mistral]
+      mistralai
+      # [bedrock]
+      boto3
+      # [modal]
+      modal
+    ];
+  };
 
   pythonRelaxDeps = [
     "tenacity"
@@ -173,7 +230,15 @@ python3.pkgs.buildPythonApplication rec {
     "pyjwt"
   ];
 
-  pythonImportsCheck = [ "hermes_cli" ];
+  pythonImportsCheck = [
+    "hermes_cli"
+    # Regression guard for #4175: these adapters swallow ImportError and only
+    # warn at runtime, so assert the underlying libraries import cleanly.
+    "slack_bolt"
+    "discord"
+    "telegram.ext"
+    "croniter"
+  ];
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [


### PR DESCRIPTION
`hermes gateway` loads platform adapters lazily and only emits a runtime warning when an extra such as slack-bolt is missing, then refuses to connect. In a Nix closure users have no way to follow the suggested `pip install 'hermes-agent[slack]'` advice, so the gateway was effectively dead on arrival.

Pull in every upstream extra that is already packaged in nixpkgs (messaging, cron, web, matrix on Linux, cli, pty, acp, voice, tts-premium, mistral, bedrock, modal) and add pythonImportsCheck entries for the adapter libraries so a future bump cannot silently regress.

Extras whose dependencies are not yet in nixpkgs (honcho, daytona, dingtalk, feishu) remain omitted.

Fixes #4175

## Summary

<!-- Briefly describe what this PR does -->

## Test plan

<!-- How did you test this change? -->

- [ ] `nix build .#<package>` succeeds
- [ ] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
