### PR TITLE
ci: bump actions to Node 24-compatible versions

### DIFF
--- a/.github/workflows/check-maintainers.yml
+++ b/.github/workflows/check-maintainers.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Need history to compute merge-base against the base branch.
           fetch-depth: 0

--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -36,7 +36,7 @@ jobs:
       matrix: ${{ steps.build-matrix.outputs.matrix }}
       has-updates: ${{ steps.build-matrix.outputs.has-updates }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup Nix
         uses: cachix/install-nix-action@v31
         with:
@@ -62,12 +62,12 @@ jobs:
     steps:
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ steps.app-token.outputs.token }}
       - name: Setup Nix
@@ -114,12 +114,12 @@ jobs:
     steps:
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ steps.app-token.outputs.token }}
           ref: main


### PR DESCRIPTION

GitHub deprecated Node.js 20 actions and will force Node.js 24 by
default starting June 2nd, 2026, with full removal on Sep 16, 2026.
Bump actions/checkout v4->v6 and actions/create-github-app-token
v1->v3, both of which now declare runs.using: node24.
cachix/install-nix-action is a composite action and unaffected.

Ref: https://github.com/numtide/llm-agents.nix/actions/runs/24814567079


