### PR TITLE
ci: add dependabot for github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,17 @@
+name: Auto Merge Dependency Updates
+on:
+  - pull_request_target
+jobs:
+  auto-merge-dependency-updates:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    concurrency:
+      group: 'auto-merge:${{ github.head_ref }}'
+      cancel-in-progress: true
+    steps:
+      - uses: Mic92/auto-merge@main
+        with:
+          use-auto-merge: true
+          merge-method: merge


### PR DESCRIPTION

Run 24814567079 surfaced Node.js deprecation warnings from outdated
actions. Dependabot keeps action versions current so these warnings
do not reappear. All action bumps are grouped into a single weekly
PR to keep noise down.
