### PR TITLE
Fix update workflow failures (bun2nix, gitnexus, entire, mcporter)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -40,16 +40,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1776182890,
-        "narHash": "sha256-+/VOe8XGq5klpU+I19D+3TcaR7o+Cwbq67KNF7mcFak=",
-        "owner": "Mic92",
+        "lastModified": 1776192490,
+        "narHash": "sha256-5gYQNEs0/vDkHhg63aHS5g0IwG/8HNvU1Vr00cElofk=",
+        "owner": "nix-community",
         "repo": "bun2nix",
-        "rev": "648d293c51e981aec9cb07ba4268bc19e7a8c575",
+        "rev": "6ef9f144616eedea90b364bb408ef2e1de7b310a",
         "type": "github"
       },
       "original": {
-        "owner": "Mic92",
-        "ref": "catalog-support",
+        "owner": "nix-community",
+        "ref": "staging-2.1.0",
         "repo": "bun2nix",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -22,10 +22,9 @@
       inputs.nixpkgs-lib.follows = "nixpkgs";
     };
     bun2nix = {
-      # TODO(#4001): switch back to github:nix-community/bun2nix once
-      # https://github.com/nix-community/bun2nix/pull/86 (catalog: support)
-      # lands upstream.
-      url = "github:Mic92/bun2nix/catalog-support";
+      # TODO(#4001): drop the branch pin once catalog support
+      # (nix-community/bun2nix#86) reaches the default branch.
+      url = "github:nix-community/bun2nix/staging-2.1.0";
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.systems.follows = "systems";
       inputs.treefmt-nix.follows = "treefmt-nix";

--- a/packages/entire/default.nix
+++ b/packages/entire/default.nix
@@ -6,5 +6,5 @@
 }:
 pkgs.callPackage ./package.nix {
   inherit flake;
-  inherit (perSystem.self) versionCheckHomeHook;
+  inherit (perSystem.self) unpinGoModVersionHook versionCheckHomeHook;
 }

--- a/packages/entire/package.nix
+++ b/packages/entire/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   flake,
   go_1_26,
+  unpinGoModVersionHook,
   versionCheckHook,
   versionCheckHomeHook,
 }:
@@ -19,11 +20,7 @@
     hash = "sha256-3sFQix4tabTs5imJCRh28azQdaUMGdVyfFxdGGqKJCg=";
   };
 
-  # Upstream bumps the toolchain directive faster than nixpkgs ships matching
-  # Go releases; the code itself does not require the exact patch level.
-  postPatch = ''
-    sed -i 's/^go 1\.26\.[0-9]*/go 1.26/' go.mod
-  '';
+  nativeBuildInputs = [ unpinGoModVersionHook ];
 
   vendorHash = "sha256-PkSN+ynGo6xW9IDoc+rX4NMt7R/d5Who0N56QyQxzl8=";
 

--- a/packages/entire/package.nix
+++ b/packages/entire/package.nix
@@ -10,16 +10,22 @@
 
 (buildGoModule.override { go = go_1_26; }) rec {
   pname = "entire";
-  version = "0.5.3";
+  version = "0.5.5";
 
   src = fetchFromGitHub {
     owner = "entireio";
     repo = "cli";
     rev = "v${version}";
-    hash = "sha256-ZQkS3bLnWFewyAXMgbbaeIjfeBumrGuKlOgzuyctNOc=";
+    hash = "sha256-3sFQix4tabTs5imJCRh28azQdaUMGdVyfFxdGGqKJCg=";
   };
 
-  vendorHash = "sha256-+QJyICYbdjZV1JJ1rKuiuryNR5q/H3PECQuarMuT39E=";
+  # Upstream bumps the toolchain directive faster than nixpkgs ships matching
+  # Go releases; the code itself does not require the exact patch level.
+  postPatch = ''
+    sed -i 's/^go 1\.26\.[0-9]*/go 1.26/' go.mod
+  '';
+
+  vendorHash = "sha256-PkSN+ynGo6xW9IDoc+rX4NMt7R/d5Who0N56QyQxzl8=";
 
   subPackages = [ "./cmd/entire" ];
 

--- a/packages/gitnexus/nix-update-args
+++ b/packages/gitnexus/nix-update-args
@@ -1,0 +1,3 @@
+--use-github-releases
+--version-regex
+^v([0-9]+\.[0-9]+\.[0-9]+)$

--- a/packages/mcporter/package.nix
+++ b/packages/mcporter/package.nix
@@ -13,18 +13,30 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "mcporter";
-  version = "0.8.1";
+  version = "0.9.0";
 
   src = fetchFromGitHub {
     owner = "steipete";
     repo = "mcporter";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-I7UqHsi4pw4wQB4bb8XObo4aUOVtYpF17aYzEHzgCrg=";
+    hash = "sha256-IH0jYDkmEPPvy/g5+YfkNBwG2QUMwkuVCnSeSTsNHNw=";
   };
 
+  # Upstream's lockfile was generated before the pnpm.overrides entry for vite
+  # was applied, so newer pnpm rejects it as out of sync with package.json.
+  # https://github.com/steipete/mcporter/issues/new (lockfile drift)
+  postPatch = ''
+    sed -i 's/specifier: \^8\.0\.8/specifier: 8.0.8/' pnpm-lock.yaml
+  '';
+
   pnpmDeps = fetchPnpmDeps {
-    inherit (finalAttrs) pname version src;
-    hash = "sha256-OJhlpKwRCE7IqstwIzj1dBJMbMyPVA/w3RVnYfjz764=";
+    inherit (finalAttrs)
+      pname
+      version
+      src
+      postPatch
+      ;
+    hash = "sha256-dCue5Id5gcddoqoHKeB3uwxR4jtoBJx/mUzHLnb8o14=";
     fetcherVersion = 2;
   };
 


### PR DESCRIPTION
## Summary

Fixes the four failing jobs from [update run 24814567079](https://github.com/numtide/llm-agents.nix/actions/runs/24814567079): the `bun2nix` flake input is moved from the deleted `Mic92:catalog-support` branch to upstream `nix-community/bun2nix/staging-2.1.0` (where nix-community/bun2nix#86 actually landed); `gitnexus` gets `nix-update-args` so it queries the GitHub releases API with a stable-only regex instead of erroring out on the rc-flooded atom feed; `entire` is bumped to 0.5.5 with a `postPatch` that relaxes the `go 1.26.2` directive to `go 1.26` until nixpkgs ships the matching patch release; and `mcporter` is bumped to 0.9.0 with a lockfile `postPatch` (shared into `fetchPnpmDeps`) to reconcile the vite override specifier that newer pnpm otherwise rejects with `ERR_PNPM_OUTDATED_LOCKFILE`.

## Test plan

- [x] `nix build .#packages.x86_64-linux.mcporter .#packages.x86_64-linux.entire` succeeds
- [x] `nix-update --flake mcporter` / `entire` complete and produce buildable derivations
- [x] `nix-update --flake gitnexus --use-github-releases --version-regex ...` exits 0 (no-op at 1.6.2)
- [x] `nix flake update bun2nix` succeeds; bun2nix consumers (`gno`, `qmd`, `oh-my-opencode`) still evaluate

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.