### PR TITLE
cursor-agent: add zlib to Linux library search path

### DIFF
--- a/packages/cursor-agent/package.nix
+++ b/packages/cursor-agent/package.nix
@@ -5,6 +5,7 @@
   makeWrapper,
   coreutils,
   wrapBuddy,
+  zlib,
   versionCheckHook,
   versionCheckHomeHook,
 }:
@@ -47,6 +48,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
     stdenv.cc.cc.lib
+    zlib
   ];
 
   unpackPhase = ''


### PR DESCRIPTION
## Summary

The recent cursor-agent tarballs bundle a `file_service.*.node` addon that links against `libz.so.1`. wrap-buddy only bakes the `lib/` directories of `buildInputs` into the loader stub, so on non-NixOS hosts the addon failed to `dlopen()` once the user actually ran the agent (the `--version` check during build does not exercise that code path). Adding `zlib` to the Linux `buildInputs` puts it on the stub's library search path; verified that the generated `.node.wrapbuddy` config now contains the zlib store path.

Fixes #4263.

## Test plan

- [x] `nix build .#packages.x86_64-linux.cursor-agent` succeeds
- [x] `.node.wrapbuddy` config includes `…/zlib-1.3.2/lib`
- [x] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.