### PR TITLE
agentsview: fix frontend assets embedding

### DIFF
--- a/packages/agentsview/package.nix
+++ b/packages/agentsview/package.nix
@@ -45,6 +45,7 @@ buildGoModule {
   env.CGO_ENABLED = "1";
 
   preBuild = ''
+    rm -rf internal/web/dist
     cp -r ${frontend} internal/web/dist
   '';
 


### PR DESCRIPTION
## Summary
This PR fixes the `agentsview` package build by ensuring frontend assets are correctly embedded into the Go binary.

## Problem
The `preBuild` phase was copying the frontend `dist` directory into an existing `internal/web/dist` folder (which contains a `.keep` file). This created a nested structure (`internal/web/dist/dist/index.html`) which Go's `go:embed all:dist` failed to serve as the expected SPA, resulting in a "Assets are not built" placeholder page.

## Solution
Added `rm -rf internal/web/dist` before copying the frontend assets to ensure `internal/web/dist/index.html` is at the correct location for embedding.