### PR TITLE
claude-code-acp: rename to claude-agent-acp

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,13 +490,13 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 ### ACP Ecosystem
 
 <details>
-<summary><strong>claude-code-acp</strong> - An ACP-compatible coding agent powered by the Claude Code SDK (TypeScript)</summary>
+<summary><strong>claude-agent-acp</strong> - An ACP-compatible coding agent powered by the Claude Code SDK (TypeScript)</summary>
 
 - **Source**: source
 - **License**: Apache-2.0
-- **Homepage**: https://github.com/zed-industries/claude-code-acp
-- **Usage**: `nix run github:numtide/llm-agents.nix#claude-code-acp -- --help`
-- **Nix**: [packages/claude-code-acp/package.nix](packages/claude-code-acp/package.nix)
+- **Homepage**: https://github.com/agentclientprotocol/claude-agent-acp
+- **Usage**: `nix run github:numtide/llm-agents.nix#claude-agent-acp -- --help`
+- **Nix**: [packages/claude-agent-acp/package.nix](packages/claude-agent-acp/package.nix)
 
 </details>
 <details>

--- a/packages/claude-agent-acp/default.nix
+++ b/packages/claude-agent-acp/default.nix
@@ -1,0 +1,8 @@
+{
+  pkgs,
+  perSystem,
+  ...
+}:
+pkgs.callPackage ./package.nix {
+  inherit (perSystem.self) buildNpmPackage;
+}

--- a/packages/claude-agent-acp/package.nix
+++ b/packages/claude-agent-acp/package.nix
@@ -6,12 +6,12 @@
 
 buildNpmPackage rec {
   npmDepsFetcherVersion = 2;
-  pname = "claude-code-acp";
+  pname = "claude-agent-acp";
   version = "0.31.0";
 
   src = fetchFromGitHub {
-    owner = "zed-industries";
-    repo = "claude-code-acp";
+    owner = "agentclientprotocol";
+    repo = "claude-agent-acp";
     rev = "v${version}";
     hash = "sha256-lWAuf8EO5Y1x1HhcNrbNQUgOsdGG5SXYTiXevWBEhSQ=";
   };
@@ -26,8 +26,8 @@ buildNpmPackage rec {
 
   meta = with lib; {
     description = "An ACP-compatible coding agent powered by the Claude Code SDK (TypeScript)";
-    homepage = "https://github.com/zed-industries/claude-code-acp";
-    changelog = "https://github.com/zed-industries/claude-code-acp/releases/tag/v${version}";
+    homepage = "https://github.com/agentclientprotocol/claude-agent-acp";
+    changelog = "https://github.com/agentclientprotocol/claude-agent-acp/releases/tag/v${version}";
     license = licenses.asl20;
     sourceProvenance = with sourceTypes; [ fromSource ];
     maintainers = with maintainers; [ ];

--- a/packages/claude-code-acp/default.nix
+++ b/packages/claude-code-acp/default.nix
@@ -3,6 +3,7 @@
   perSystem,
   ...
 }:
-pkgs.callPackage ./package.nix {
-  inherit (perSystem.self) buildNpmPackage;
+pkgs.lib.warnOnInstantiate "'claude-code-acp' has been renamed to 'claude-agent-acp'. Please update your references." perSystem.self.claude-agent-acp
+// {
+  passthru.hideFromDocs = true;
 }


### PR DESCRIPTION
## Summary

Upstream renamed and moved orgs:
- agentclientprotocol/claude-agent-acp#319
- agentclientprotocol/claude-agent-acp#471

The old name is kept as a deprecated alias with a warning.

## Test plan

- [x] `nix build .#<package>` succeeds
- [x] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work