### PR TITLE
claude-code: 2.1.120 -> 2.1.119 (upstream rollback)

### DIFF
--- a/packages/claude-code/hashes.json
+++ b/packages/claude-code/hashes.json
@@ -1,9 +1,9 @@
 {
-  "version": "2.1.120",
+  "version": "2.1.119",
   "hashes": {
-    "x86_64-linux": "sha256-EsDW62053CWX/RMdjqTxLti/JbR9rdkXOHjm0CWVnJ8=",
-    "aarch64-linux": "sha256-ptDSWUbDKiS04ERxr3CEWkVCjKBp+ztIk0XypoMmInk=",
-    "x86_64-darwin": "sha256-rWjyJeltuLfRLQwx8DQ7wyJ+oohuzvri9IPLMjELAAQ=",
-    "aarch64-darwin": "sha256-+tj69Jx7G0VMONeFt14X7b2tx/+vRQsxNJqvxlYLjvY="
+    "x86_64-linux": "sha256-zKQwU/BilJSVWWsRtv0bWc95ECrbE7rL5mmX5vrkHko=",
+    "aarch64-linux": "sha256-OCqnPqSwf9jWmOMVm1754bhzn651BbqN3Si4pqYoGc4=",
+    "x86_64-darwin": "sha256-UrO3XP6AxiaYKy/7Omzhx5eCTyV9wnXPCjwywgK2o98=",
+    "aarch64-darwin": "sha256-Mds0RDCdXQ+Lheh4Li3NhvMffkjBoeg9abCSaMe0+aI="
   }
 }

--- a/packages/claude-code/update.py
+++ b/packages/claude-code/update.py
@@ -17,7 +17,6 @@ from updater import (
     fetch_text,
     load_hashes,
     save_hashes,
-    should_update,
 )
 from updater.hash import hex_to_sri
 
@@ -56,7 +55,11 @@ def main() -> None:
 
     print(f"Current: {current}, Latest: {latest}")
 
-    if not should_update(current, latest):
+    # Follow the upstream `latest` pointer exactly, including downgrades:
+    # Anthropic rolls bad releases back by repointing it (e.g. 2.1.120 was
+    # yanked back to 2.1.119), and should_update() would leave us pinned to
+    # the broken build.
+    if current == latest:
         print("Already up to date")
         return
 


### PR DESCRIPTION
Anthropic yanked 2.1.120 after a sandbox regression broke `--resume`
("sandbox.failIfUnavailable is set - refusing to start without a working
sandbox") and repointed both the npm `latest` tag and the GCS `latest`
endpoint back to 2.1.119.

Our updater used should_update(), which only moves forward, so it would
never pick up such a rollback. Switch to following the `latest` pointer
verbatim so future yanks self-heal.

Fixes #4321
