### PR TITLE
buildNpmPackage: add eval guard for fetcherVersion=2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -232,6 +232,8 @@ fi
 
 ### Common Issues and Solutions
 
+1. **npm packages**: Use `perSystem.self.buildNpmPackage` (not `pkgs.buildNpmPackage`) in `default.nix`. It is the same builder plus an eval-time guard that fails fast with a helpful message when the consumer's nixpkgs predates `fetcherVersion = 2`, instead of a cryptic FOD hash mismatch (#4320).
+
 1. **Rust packages with git dependencies**: May fail during cargo vendoring if dependencies have workspace inheritance issues. Consider using pre-built binaries as a workaround.
 
 1. **Binary packages**: When packaging pre-built binaries:

--- a/packages/auto-claude/default.nix
+++ b/packages/auto-claude/default.nix
@@ -1,8 +1,10 @@
 {
   pkgs,
   flake,
+  perSystem,
   ...
 }:
 pkgs.callPackage ./package.nix {
   inherit flake;
+  inherit (perSystem.self) buildNpmPackage;
 }

--- a/packages/buildNpmPackage/default.nix
+++ b/packages/buildNpmPackage/default.nix
@@ -1,0 +1,46 @@
+{ pkgs, ... }:
+# Re-export of nixpkgs' buildNpmPackage with an eval-time guard.
+#
+# Several packages here set `npmDepsFetcherVersion = 2`, whose FOD output (and
+# thus the committed npmDepsHash) depends on prefetch-npm-deps caching
+# packuments. On nixpkgs revisions predating that support the attribute is
+# silently ignored and the FOD falls back to v1 behaviour, surfacing only as a
+# confusing `hash mismatch in fixed-output derivation …-npm-deps.drv` (#4320).
+#
+# The guard fires for every consumption path that swaps out nixpkgs
+# (overlays.shared-nixpkgs, `inputs.llm-agents.inputs.nixpkgs.follows`, direct
+# callPackage), because blueprint builds perSystem.self against whatever `pkgs`
+# is in effect.
+let
+  inherit (pkgs) lib;
+  hasFetcherVersion = (lib.functionArgs pkgs.fetchNpmDeps) ? fetcherVersion;
+  msg = ''
+    llm-agents.nix: this nixpkgs is too old for our npm packages.
+
+    fetchNpmDeps lacks the `fetcherVersion` argument, so the committed
+    npmDepsHash (computed with fetcherVersion = 2) cannot match. You are
+    likely on nixos-25.11 or an early-2026 unstable via
+    `overlays.shared-nixpkgs` or `inputs.llm-agents.inputs.nixpkgs.follows`.
+
+    Either use `overlays.default` / the flake packages directly, or bump
+    nixpkgs to at least 203662a570c4 (2026-02-15). See
+    https://github.com/numtide/llm-agents.nix/issues/4320.
+  '';
+in
+# A real (empty) derivation so blueprint / buildbot can enumerate and "build"
+# it, plus a __functor that forwards to the actual builder so
+# `perSystem.self.buildNpmPackage { … }` works in package.nix.
+pkgs.emptyDirectory.overrideAttrs { name = "buildNpmPackage-guard"; }
+// {
+  __functor =
+    _:
+    assert lib.assertMsg hasFetcherVersion msg;
+    pkgs.buildNpmPackage;
+  override = pkgs.buildNpmPackage.override;
+  passthru.hideFromDocs = true;
+  meta = {
+    description = "nixpkgs buildNpmPackage with an eval guard for fetcherVersion=2";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.all;
+  };
+}

--- a/packages/claude-code-acp/default.nix
+++ b/packages/claude-code-acp/default.nix
@@ -1,6 +1,8 @@
 {
   pkgs,
+  perSystem,
   ...
 }:
 pkgs.callPackage ./package.nix {
+  inherit (perSystem.self) buildNpmPackage;
 }

--- a/packages/copilot-language-server/default.nix
+++ b/packages/copilot-language-server/default.nix
@@ -1,7 +1,9 @@
 {
   pkgs,
+  perSystem,
   ...
 }:
 pkgs.callPackage ./package.nix {
   nodejs = pkgs.nodejs_24;
+  inherit (perSystem.self) buildNpmPackage;
 }

--- a/packages/gemini-cli/default.nix
+++ b/packages/gemini-cli/default.nix
@@ -1,5 +1,5 @@
 { pkgs, perSystem, ... }:
 pkgs.callPackage ./package.nix {
   darwinOpenptyHook = pkgs.callPackage ../darwinOpenptyHook { };
-  inherit (perSystem.self) versionCheckHomeHook;
+  inherit (perSystem.self) buildNpmPackage versionCheckHomeHook;
 }

--- a/packages/gitclaw/default.nix
+++ b/packages/gitclaw/default.nix
@@ -1,4 +1,10 @@
-{ pkgs, flake, ... }:
+{
+  pkgs,
+  flake,
+  perSystem,
+  ...
+}:
 pkgs.callPackage ./package.nix {
   inherit flake;
+  inherit (perSystem.self) buildNpmPackage;
 }

--- a/packages/gitnexus/default.nix
+++ b/packages/gitnexus/default.nix
@@ -1,4 +1,10 @@
-{ pkgs, flake, ... }:
+{
+  pkgs,
+  flake,
+  perSystem,
+  ...
+}:
 pkgs.callPackage ./package.nix {
   inherit flake;
+  inherit (perSystem.self) buildNpmPackage;
 }

--- a/packages/iflow-cli/default.nix
+++ b/packages/iflow-cli/default.nix
@@ -1,3 +1,4 @@
-{ pkgs }:
+{ pkgs, perSystem }:
 pkgs.callPackage ./package.nix {
+  inherit (perSystem.self) buildNpmPackage;
 }

--- a/packages/letta-code/default.nix
+++ b/packages/letta-code/default.nix
@@ -4,5 +4,5 @@
   ...
 }:
 pkgs.callPackage ./package.nix {
-  inherit (perSystem.self) versionCheckHomeHook;
+  inherit (perSystem.self) buildNpmPackage versionCheckHomeHook;
 }

--- a/packages/oh-my-claudecode/default.nix
+++ b/packages/oh-my-claudecode/default.nix
@@ -1,4 +1,10 @@
-{ pkgs, flake, ... }:
+{
+  pkgs,
+  flake,
+  perSystem,
+  ...
+}:
 pkgs.callPackage ./package.nix {
   inherit flake;
+  inherit (perSystem.self) buildNpmPackage;
 }

--- a/packages/oh-my-codex/default.nix
+++ b/packages/oh-my-codex/default.nix
@@ -6,5 +6,5 @@
 }:
 pkgs.callPackage ./package.nix {
   inherit flake;
-  codex = perSystem.self.codex;
+  inherit (perSystem.self) buildNpmPackage codex;
 }

--- a/packages/openskills/default.nix
+++ b/packages/openskills/default.nix
@@ -1,4 +1,9 @@
-{ pkgs, flake }:
+{
+  pkgs,
+  flake,
+  perSystem,
+}:
 pkgs.callPackage ./package.nix {
   inherit flake;
+  inherit (perSystem.self) buildNpmPackage;
 }

--- a/packages/openspec/default.nix
+++ b/packages/openspec/default.nix
@@ -1,3 +1,4 @@
-{ pkgs }:
+{ pkgs, perSystem }:
 pkgs.callPackage ./package.nix {
+  inherit (perSystem.self) buildNpmPackage;
 }

--- a/packages/openspecui/default.nix
+++ b/packages/openspecui/default.nix
@@ -1,4 +1,10 @@
-{ pkgs, flake, ... }:
+{
+  pkgs,
+  flake,
+  perSystem,
+  ...
+}:
 pkgs.callPackage ./package.nix {
   inherit flake;
+  inherit (perSystem.self) buildNpmPackage;
 }

--- a/packages/pi/default.nix
+++ b/packages/pi/default.nix
@@ -4,5 +4,5 @@
   ...
 }:
 pkgs.callPackage ./package.nix {
-  inherit (perSystem.self) versionCheckHomeHook;
+  inherit (perSystem.self) buildNpmPackage versionCheckHomeHook;
 }

--- a/packages/qwen-code/default.nix
+++ b/packages/qwen-code/default.nix
@@ -1,4 +1,5 @@
-{ pkgs }:
+{ pkgs, perSystem }:
 pkgs.callPackage ./package.nix {
   darwinOpenptyHook = pkgs.callPackage ../darwinOpenptyHook { };
+  inherit (perSystem.self) buildNpmPackage;
 }

--- a/packages/sandbox-runtime/default.nix
+++ b/packages/sandbox-runtime/default.nix
@@ -1,4 +1,5 @@
-{ pkgs, ... }:
+{ pkgs, perSystem, ... }:
 pkgs.callPackage ./package.nix {
   nodejs = pkgs.nodejs_24;
+  inherit (perSystem.self) buildNpmPackage;
 }


### PR DESCRIPTION
Packages that set npmDepsFetcherVersion = 2 record an npmDepsHash that
includes cached packuments. When a consumer swaps in an older nixpkgs
(via overlays.shared-nixpkgs or inputs.nixpkgs.follows) whose
fetchNpmDeps predates the fetcherVersion argument, the FOD silently
falls back to v1 output and surfaces only as an opaque "hash mismatch in
fixed-output derivation ...-npm-deps.drv" (#4320).

Expose a guarded buildNpmPackage via perSystem.self: it is an empty
derivation (so blueprint/buildbot can enumerate and build it) with a
__functor that asserts fetchNpmDeps takes fetcherVersion before
forwarding to the real builder. Wire all npmDepsFetcherVersion=2
packages through it. drvPaths are unchanged on our pinned nixpkgs, so
the binary cache is unaffected.

Fixes #4320
