### PR TITLE
Add rustPlatform.bindgenHook to codex for Darwin platform

### DIFF
--- a/packages/codex/package.nix
+++ b/packages/codex/package.nix
@@ -73,6 +73,10 @@ rustPlatform.buildRustPackage {
     installShellFiles
     makeWrapper
     pkg-config
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # Unable to find libclang: "couldn't find any valid shared libraries matching: ['libclang.dylib']
+    rustPlatform.bindgenHook
   ];
 
   buildInputs = [ openssl ] ++ lib.optionals stdenv.hostPlatform.isLinux [ libcap ];


### PR DESCRIPTION
## Summary

Fixes #4402 

## Test plan

<!-- How did you test this change? -->

- [ ] `nix build .#<package>` succeeds
- [ ] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
