### PR TITLE
omp: support darwin

### DIFF
--- a/packages/omp/package.nix
+++ b/packages/omp/package.nix
@@ -18,6 +18,43 @@
 let
   versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
   inherit (versionData) version hash cargoHash;
+  platformsBySystem = {
+    aarch64-darwin = {
+      bunTarget = "bun-darwin-arm64";
+      nativeLib = "libpi_natives.dylib";
+      nodeTag = "darwin-arm64";
+    };
+    aarch64-linux = {
+      bunTarget = "bun-linux-arm64";
+      nativeLib = "libpi_natives.so";
+      nodeTag = "linux-arm64";
+    };
+    x86_64-darwin = {
+      bunTarget = "bun-darwin-x64";
+      nativeLib = "libpi_natives.dylib";
+      nodeTag = "darwin-x64";
+    };
+    x86_64-linux = {
+      bunTarget = "bun-linux-x64-modern";
+      nativeLib = "libpi_natives.so";
+      nodeTag = "linux-x64";
+    };
+  };
+  platform =
+    platformsBySystem.${stdenv.hostPlatform.system}
+      or (throw "Unsupported platform for omp: ${stdenv.hostPlatform.system}");
+  rustTarget = stdenv.hostPlatform.rust.rustcTarget;
+  rustTargetEnv = "CARGO_TARGET_${
+    lib.toUpper (builtins.replaceStrings [ "-" ] [ "_" ] rustTarget)
+  }_RUSTFLAGS";
+  glimmerRustFlags = lib.concatStringsSep " " [
+    "-Clink-arg=-Wl,-u,tree_sitter_glimmer_external_scanner_create"
+    "-Clink-arg=-Wl,-u,tree_sitter_glimmer_external_scanner_destroy"
+    "-Clink-arg=-Wl,-u,tree_sitter_glimmer_external_scanner_reset"
+    "-Clink-arg=-Wl,-u,tree_sitter_glimmer_external_scanner_scan"
+    "-Clink-arg=-Wl,-u,tree_sitter_glimmer_external_scanner_serialize"
+    "-Clink-arg=-Wl,-u,tree_sitter_glimmer_external_scanner_deserialize"
+  ];
 
   src = fetchFromGitHub {
     owner = "can1357";
@@ -55,15 +92,10 @@ stdenv.mkDerivation {
 
   # smallvec's `specialization` feature requires nightly Rust.
   # RUSTC_BOOTSTRAP=1 enables nightly features on stable rustc.
-  env.RUSTC_BOOTSTRAP = 1;
-  env.RUSTFLAGS = lib.concatStringsSep " " [
-    "-Clink-arg=-Wl,-u,tree_sitter_glimmer_external_scanner_create"
-    "-Clink-arg=-Wl,-u,tree_sitter_glimmer_external_scanner_destroy"
-    "-Clink-arg=-Wl,-u,tree_sitter_glimmer_external_scanner_reset"
-    "-Clink-arg=-Wl,-u,tree_sitter_glimmer_external_scanner_scan"
-    "-Clink-arg=-Wl,-u,tree_sitter_glimmer_external_scanner_serialize"
-    "-Clink-arg=-Wl,-u,tree_sitter_glimmer_external_scanner_deserialize"
-  ];
+  env = {
+    RUSTC_BOOTSTRAP = 1;
+    ${rustTargetEnv} = glimmerRustFlags;
+  };
 
   bunDeps = bun2nix.fetchBunDeps {
     bunNix = ./bun.nix;
@@ -104,106 +136,85 @@ stdenv.mkDerivation {
     PLACEHOLDER
   '';
 
-  buildPhase =
-    let
-      platformTag =
-        if stdenv.hostPlatform.isx86_64 then
-          "linux-x64"
-        else if stdenv.hostPlatform.isAarch64 then
-          "linux-arm64"
-        else
-          throw "Unsupported platform for omp";
-      bunTarget =
-        if stdenv.hostPlatform.isx86_64 then
-          "bun-linux-x64-modern"
-        else if stdenv.hostPlatform.isAarch64 then
-          "bun-linux-arm64"
-        else
-          throw "Unsupported platform for omp";
-    in
-    ''
-      runHook preBuild
+  buildPhase = ''
+    runHook preBuild
 
-      # Native node modules like @napi-rs/cli need libstdc++ at build time
-      ${lib.optionalString stdenv.hostPlatform.isLinux ''
-        export LD_LIBRARY_PATH="${lib.makeLibraryPath [ stdenv.cc.cc.lib ]}"
-      ''}
+    # Native node modules like @napi-rs/cli need libstdc++ at build time
+    ${lib.optionalString stdenv.hostPlatform.isLinux ''
+      export LD_LIBRARY_PATH="${lib.makeLibraryPath [ stdenv.cc.cc.lib ]}"
+    ''}
 
-      # bindgen (used by zlob crate) needs libclang
-      export LIBCLANG_PATH="${libclang.lib}/lib"
+    # bindgen (used by zlob crate) needs libclang
+    export LIBCLANG_PATH="${libclang.lib}/lib"
 
-      # Build the Rust native addon
-      echo "Building Rust native addon..."
-      cargo build --release -p pi-natives --target-dir target
+    # Build the Rust native addon
+    echo "Building Rust native addon..."
+    cargo build --release -p pi-natives --target ${rustTarget} --target-dir target
 
-      # Install the native addon where the JS code expects it
-      mkdir -p packages/natives/native
-      cp target/release/libpi_natives.so \
-         packages/natives/native/pi_natives.${platformTag}.node
+    # Install the native addon where the JS code expects it
+    mkdir -p packages/natives/native
+    cp target/${rustTarget}/release/${platform.nativeLib} \
+       packages/natives/native/pi_natives.${platform.nodeTag}.node
 
-      # Generate the napi type definitions and JS loader by running the
-      # napi CLI from node_modules
-      napiBin="$(pwd)/node_modules/.bin/napi"
-      if [ -x "$napiBin" ]; then
-        "$napiBin" build \
-          --manifest-path crates/pi-natives/Cargo.toml \
-          --package-json-path packages/natives/package.json \
-          --platform \
-          --no-js \
-          --dts index.d.ts \
-          -o packages/natives/native \
-          --release \
-          || echo "napi CLI post-processing failed; using cargo output directly"
-      fi
+    # Generate the napi type definitions and JS loader by running the
+    # napi CLI from node_modules
+    napiBin="$(pwd)/node_modules/.bin/napi"
+    if [ -x "$napiBin" ]; then
+      "$napiBin" build \
+        --manifest-path crates/pi-natives/Cargo.toml \
+        --package-json-path packages/natives/package.json \
+        --platform \
+        --no-js \
+        --dts index.d.ts \
+        -o packages/natives/native \
+        --release \
+        || echo "napi CLI post-processing failed; using cargo output directly"
+    fi
 
-      # Generate runtime enum exports from const enums in the type definitions
-      if [ -f packages/natives/scripts/gen-enums.ts ] && \
-         [ -f packages/natives/native/index.d.ts ]; then
-        bun packages/natives/scripts/gen-enums.ts || true
-      fi
+    # Generate runtime enum exports from const enums in the type definitions
+    if [ -f packages/natives/scripts/gen-enums.ts ] && \
+       [ -f packages/natives/native/index.d.ts ]; then
+      bun packages/natives/scripts/gen-enums.ts || true
+    fi
 
-      # Generate the docs index (prepack script in coding-agent)
-      echo "Generating docs index..."
-      bun packages/coding-agent/scripts/generate-docs-index.ts
+    # Generate the docs index (prepack script in coding-agent)
+    echo "Generating docs index..."
+    bun packages/coding-agent/scripts/generate-docs-index.ts
 
-      # Compile the standalone binary
-      echo "Compiling standalone binary..."
-      bun build --compile \
-        --define PI_COMPILED=true \
-        --external mupdf \
-        --target="${bunTarget}" \
-        --root . \
-        ./packages/coding-agent/src/cli.ts \
-        --outfile dist/omp
+    # Compile the standalone binary
+    echo "Compiling standalone binary..."
+    bun build --compile \
+      --define PI_COMPILED=true \
+      --external mupdf \
+      --target="${platform.bunTarget}" \
+      --root . \
+      ./packages/coding-agent/src/cli.ts \
+      --outfile dist/omp
 
-      runHook postBuild
-    '';
+    runHook postBuild
+  '';
 
-  installPhase =
-    let
-      platformTag = if stdenv.hostPlatform.isAarch64 then "linux-arm64" else "linux-x64";
-    in
-    ''
-      runHook preInstall
+  installPhase = ''
+    runHook preInstall
 
-      mkdir -p $out/lib/omp $out/bin
-      cp dist/omp $out/lib/omp/omp
-      # native.ts probes dirname(process.execPath) for the addon. On x64 it
-      # looks for -modern / -baseline / plain in that order, on arm64 only
-      # the plain name. Ship the plain name so both arches resolve it.
-      cp packages/natives/native/pi_natives.${platformTag}.node $out/lib/omp/
+    mkdir -p $out/lib/omp $out/bin
+    cp dist/omp $out/lib/omp/omp
+    # native.ts probes dirname(process.execPath) for the addon. On x64 it
+    # looks for -modern / -baseline / plain in that order, on arm64 only
+    # the plain name. Ship the plain name so both arches resolve it.
+    cp packages/natives/native/pi_natives.${platform.nodeTag}.node $out/lib/omp/
 
-      makeWrapper $out/lib/omp/omp $out/bin/omp \
-        --set PI_SKIP_VERSION_CHECK 1 \
-      ${lib.optionalString stdenv.hostPlatform.isLinux "--prefix LD_LIBRARY_PATH : ${
-        lib.makeLibraryPath [
-          zlib
-          stdenv.cc.cc.lib
-        ]
-      }"}
+    makeWrapper $out/lib/omp/omp $out/bin/omp \
+      --set PI_SKIP_VERSION_CHECK 1 \
+    ${lib.optionalString stdenv.hostPlatform.isLinux "--prefix LD_LIBRARY_PATH : ${
+      lib.makeLibraryPath [
+        zlib
+        stdenv.cc.cc.lib
+      ]
+    }"}
 
-      runHook postInstall
-    '';
+    runHook postInstall
+  '';
 
   passthru.category = "AI Coding Agents";
 
@@ -215,6 +226,6 @@ stdenv.mkDerivation {
     sourceProvenance = with lib.sourceTypes; [ fromSource ];
     maintainers = with maintainers; [ aldoborrero ];
     mainProgram = "omp";
-    platforms = platforms.linux;
+    platforms = builtins.attrNames platformsBySystem;
   };
 }


### PR DESCRIPTION
## Summary

Add Darwin support for `omp` on `aarch64-darwin` and `x86_64-darwin`.

This centralizes the platform-specific build metadata for the four supported systems and uses it for Bun compile targets, native addon filenames, and packaged node addon tags. It also scopes the `tree_sitter_glimmer` linker flags to the Rust host target instead of applying them globally, which fixes Darwin build-script linking while preserving the existing Linux behavior.

## Test plan

- [x] `nix build path:.#omp`
- [x] `./result/bin/omp --help`
- [x] `nix build path:.#checks.aarch64-darwin.pkgs-omp`
- [x] `nix build path:.#checks.aarch64-darwin.pkgs-formatter-check`
- [x] `nix build path:.#checks.aarch64-darwin.meta-maintainers`
- [x] `nix flake check path:. --no-build`
- [x] Evaluated `omp.drvPath` for `aarch64-darwin`, `x86_64-darwin`, `aarch64-linux`, and `x86_64-linux`

Local machine is `aarch64-darwin`; Linux and `x86_64-darwin` were evaluation-checked locally, not built locally.
