### PR TITLE
add the td tool as an alternative option to beads

### DIFF
--- a/README.md
+++ b/README.md
@@ -717,6 +717,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>td</strong> - A minimalist CLI for tracking tasks across AI coding sessions.</summary>
+
+- **Source**: source
+- **License**: MIT
+- **Homepage**: https://github.com/marcus/td
+- **Usage**: `nix run github:numtide/llm-agents.nix#td -- --help`
+- **Nix**: [packages/td/package.nix](packages/td/package.nix)
+
+</details>
+<details>
 <summary><strong>vibe-kanban</strong> - Kanban board to orchestrate AI coding agents like Claude Code, Codex, and Gemini CLI</summary>
 
 - **Source**: source

--- a/packages/td/default.nix
+++ b/packages/td/default.nix
@@ -1,0 +1,8 @@
+{
+  pkgs,
+  flake,
+  ...
+}:
+pkgs.callPackage ./package.nix {
+  inherit flake;
+}

--- a/packages/td/package.nix
+++ b/packages/td/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  flake,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+}:
+
+buildGoModule rec {
+  pname = "td";
+  version = "0.44.0";
+
+  src = fetchFromGitHub {
+    owner = "marcus";
+    repo = "td";
+    rev = "v${version}";
+    hash = "sha256-k1OCK6LE99fHLuxv8HZUW8cSn2Wmk74J7kb6Mi5ZpVw=";
+  };
+
+  vendorHash = "sha256-hFFG+vLXcL2NNdLQvQZ1hzu++pp5AkbFOPQS10wtsec=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X=main.Version=${version}"
+  ];
+
+  doCheck = false;
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.category = "Workflow & Project Management";
+
+  meta = with lib; {
+    description = "A minimalist CLI for tracking tasks across AI coding sessions.";
+    homepage = "https://github.com/marcus/td";
+    changelog = "https://github.com/marcus/td/releases/tag/v${version}";
+    license = licenses.mit;
+    sourceProvenance = with sourceTypes; [ fromSource ];
+    maintainers = with flake.lib.maintainers; [ afterthought ];
+    mainProgram = "td";
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}


### PR DESCRIPTION
## Summary

Adds the [td](https://github.com/marcus/td) tool as an alternative to beads

## Test plan

Ran the checks and tested the nix build.

- [X] `nix build .#<package>` succeeds
- [X] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

I am not particularly familiar with nix-update, but this is a straightforward go package. Based on other similar go implementations in this repository that apparently work with nix-update, and a quick perusal of its docs I expect this should work the same as those.

