### PR TITLE
agentsview: 0.26.0 -> 0.25.0 (upstream regression)

### DIFF
--- a/packages/agentsview/hashes.json
+++ b/packages/agentsview/hashes.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.26.0",
-  "hash": "sha256-3oTz5W1KB+Qna6uBf5fSsgGB2+qhS/zrZSbd79y8t1Q=",
+  "version": "0.25.0",
+  "hash": "sha256-rPb4qgoN0kFK4BG/eWe2ii1MwAKGAimci+esyyVSBrQ=",
   "npmDepsHash": "sha256-mTm/JaQENbEnz/0pyqPCqhaS3b02DoEj+Zf6wVNiIyU=",
   "vendorHash": "sha256-Lxyl5TMwJuezFH1eMQC3HHPKplGYCcfDCx4X3VrAAAw="
 }

--- a/packages/agentsview/update.py
+++ b/packages/agentsview/update.py
@@ -1,76 +1,8 @@
-#!/usr/bin/env nix
-#! nix shell --inputs-from .# nixpkgs#python3 --command python3
+#!/usr/bin/env python3
+"""Prevent automated agentsview bumps while 0.26.0 suffers a frontend regression.
 
-"""Update script for agentsview package."""
+Restore the original updater by reverting this file (see git history) once
+wesm/agentsview#428 is fixed.
+"""
 
-import sys
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
-
-from updater import (
-    calculate_dependency_hash,
-    calculate_url_hash,
-    fetch_github_latest_release,
-    load_hashes,
-    save_hashes,
-    should_update,
-)
-from updater.hash import DUMMY_SHA256_HASH
-from updater.nix import NixCommandError
-
-HASHES_FILE = Path(__file__).parent / "hashes.json"
-
-
-def main() -> None:
-    """Update the agentsview package."""
-    data = load_hashes(HASHES_FILE)
-    current = data["version"]
-    latest = fetch_github_latest_release("wesm", "agentsview")
-
-    print(f"Current: {current}, Latest: {latest}")
-
-    if not should_update(current, latest):
-        print("Already up to date")
-        return
-
-    url = f"https://github.com/wesm/agentsview/archive/refs/tags/v{latest}.tar.gz"
-
-    print("Calculating source hash...")
-    source_hash = calculate_url_hash(url, unpack=True)
-
-    data = {
-        "version": latest,
-        "hash": source_hash,
-        "npmDepsHash": DUMMY_SHA256_HASH,
-        "vendorHash": DUMMY_SHA256_HASH,
-    }
-    save_hashes(HASHES_FILE, data)
-
-    try:
-        print("Calculating npmDepsHash...")
-        npm_deps_hash = calculate_dependency_hash(
-            ".#agentsview", "npmDepsHash", HASHES_FILE, data
-        )
-        data["npmDepsHash"] = npm_deps_hash
-        save_hashes(HASHES_FILE, data)
-    except (ValueError, NixCommandError) as e:
-        print(f"Error calculating npmDepsHash: {e}")
-        return
-
-    try:
-        print("Calculating vendorHash...")
-        vendor_hash = calculate_dependency_hash(
-            ".#agentsview", "vendorHash", HASHES_FILE, data
-        )
-        data["vendorHash"] = vendor_hash
-        save_hashes(HASHES_FILE, data)
-    except (ValueError, NixCommandError) as e:
-        print(f"Error calculating vendorHash: {e}")
-        return
-
-    print(f"Updated to {latest}")
-
-
-if __name__ == "__main__":
-    main()
+print("Skipping agentsview update: pinned to 0.25.0 due to upstream regression.")


### PR DESCRIPTION
0.26.0 has a frontend regression that breaks session viewing in the web UI: clicking a session leaves the message panel empty, and the session list sidebar doesn't paginate past the first page. Filed upstream at https://github.com/wesm/agentsview/issues/428.

Verified locally: 0.25.0 against the same Postgres dataset renders correctly; 0.26.0 doesn't. `npmDepsHash` and `vendorHash` are unchanged between the two releases, so the regression is frontend-only.

Block automated bumps with a stub `update.py`, matching the copilot-cli pattern from #1716. Restore the original updater by reverting this commit once upstream ships a fix.