### PR TITLE
ci: preserve manual commits on update PR branches

### DIFF
--- a/.github/ci/create_pr.py
+++ b/.github/ci/create_pr.py
@@ -82,11 +82,15 @@ def build_config(
 
 
 def create_or_update_pr(config: PrConfig, *, labels: str, auto_merge: bool) -> None:
-    """Stage, commit, push, and create/update the PR."""
+    """Stage, commit, push, and create/update the PR.
+
+    The workflow's "Prepare update branch" step has already checked out
+    ``config.branch`` (rebased onto main if it existed), so we only need to
+    commit the updater's changes on top and force-push.
+    """
     run(["git", "add", "."])
-    run(["git", "checkout", "-b", config.branch])
     run(["git", "commit", "-m", config.commit_message, "--signoff"])
-    run(["git", "push", "--force", "origin", config.branch])
+    run(["git", "push", "--force", "origin", f"HEAD:{config.branch}"])
 
     pr_number = gh_get_pr_number(config.branch)
 

--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -70,6 +70,8 @@ jobs:
         uses: actions/checkout@v6
         with:
           token: ${{ steps.app-token.outputs.token }}
+          # Full history needed so we can rebase existing update/* branches onto main.
+          fetch-depth: 0
       - name: Setup Nix
         uses: cachix/install-nix-action@v31
         with:
@@ -80,6 +82,27 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      - name: Prepare update branch
+        # Reuse the existing update/* branch (if any) so manual fixup commits on the
+        # open PR are preserved. Rebase it onto main and let the updater commit on top.
+        run: |
+          if [[ "${{ matrix.type }}" = package ]]; then
+            branch="update/${{ matrix.name }}"
+          else
+            branch="update-${{ matrix.name }}"
+          fi
+          git fetch origin main
+          if git fetch origin "$branch"; then
+            echo "Reusing existing branch $branch"
+            git checkout -B "$branch" "origin/$branch"
+            if ! git rebase origin/main; then
+              echo "::warning::Rebase of $branch onto main failed, discarding stale branch"
+              git rebase --abort
+              git reset --hard origin/main
+            fi
+          else
+            git checkout -B "$branch" origin/main
+          fi
       - name: Perform update
         id: update
         env:


### PR DESCRIPTION
The updater previously force-pushed a fresh single-commit branch built from `main`, which discarded any manual fixup commits maintainers had pushed onto an open `update/*` PR.

Reuse the existing branch instead: rebase it onto `main` before running the updater and stack the new version bump on top, so those fixups survive and the PR stays current with main.