### PR TITLE
agentsview: restore update.py — wesm/agentsview#429 fixed regression

### DIFF
--- a/packages/agentsview/update.py
+++ b/packages/agentsview/update.py
@@ -1,8 +1,76 @@
-#!/usr/bin/env python3
-"""Prevent automated agentsview bumps while 0.26.0 suffers a frontend regression.
+#!/usr/bin/env nix
+#! nix shell --inputs-from .# nixpkgs#python3 --command python3
 
-Restore the original updater by reverting this file (see git history) once
-wesm/agentsview#428 is fixed.
-"""
+"""Update script for agentsview package."""
 
-print("Skipping agentsview update: pinned to 0.25.0 due to upstream regression.")
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+
+from updater import (
+    calculate_dependency_hash,
+    calculate_url_hash,
+    fetch_github_latest_release,
+    load_hashes,
+    save_hashes,
+    should_update,
+)
+from updater.hash import DUMMY_SHA256_HASH
+from updater.nix import NixCommandError
+
+HASHES_FILE = Path(__file__).parent / "hashes.json"
+
+
+def main() -> None:
+    """Update the agentsview package."""
+    data = load_hashes(HASHES_FILE)
+    current = data["version"]
+    latest = fetch_github_latest_release("wesm", "agentsview")
+
+    print(f"Current: {current}, Latest: {latest}")
+
+    if not should_update(current, latest):
+        print("Already up to date")
+        return
+
+    url = f"https://github.com/wesm/agentsview/archive/refs/tags/v{latest}.tar.gz"
+
+    print("Calculating source hash...")
+    source_hash = calculate_url_hash(url, unpack=True)
+
+    data = {
+        "version": latest,
+        "hash": source_hash,
+        "npmDepsHash": DUMMY_SHA256_HASH,
+        "vendorHash": DUMMY_SHA256_HASH,
+    }
+    save_hashes(HASHES_FILE, data)
+
+    try:
+        print("Calculating npmDepsHash...")
+        npm_deps_hash = calculate_dependency_hash(
+            ".#agentsview", "npmDepsHash", HASHES_FILE, data
+        )
+        data["npmDepsHash"] = npm_deps_hash
+        save_hashes(HASHES_FILE, data)
+    except (ValueError, NixCommandError) as e:
+        print(f"Error calculating npmDepsHash: {e}")
+        return
+
+    try:
+        print("Calculating vendorHash...")
+        vendor_hash = calculate_dependency_hash(
+            ".#agentsview", "vendorHash", HASHES_FILE, data
+        )
+        data["vendorHash"] = vendor_hash
+        save_hashes(HASHES_FILE, data)
+    except (ValueError, NixCommandError) as e:
+        print(f"Error calculating vendorHash: {e}")
+        return
+
+    print(f"Updated to {latest}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The skip stub from #4477 has done its job. [wesm/agentsview#429](https://github.com/wesm/agentsview/pull/429) (merged) fixes the timing-endpoint nil-slice bug that caused the 0.26.0 frontend to throw on every session view.

Once a release tag containing the fix is cut, the daily updater should pick it up; restoring \`update.py\` unblocks that. \`hashes.json\` stays at 0.25.0 — the next successful run of the updater bumps it.