### PR TITLE
code-review-graph: fix  lupa.lua51 crash

### DIFF
--- a/packages/code-review-graph/package.nix
+++ b/packages/code-review-graph/package.nix
@@ -12,6 +12,25 @@ let
       # (some async tests block past the 3h builder timeout). Skip checks
       # since we only need it as a runtime dependency.
       fastmcp = prev.fastmcp.overridePythonAttrs { doCheck = false; };
+
+      # The pinned nixpkgs builds lupa with `LUPA_NO_BUNDLE` against system
+      # luajit, which only yields a single `lupa.lua` backend module.
+      # fakeredis (pulled in via fastmcp -> pydocket) hard-codes
+      # `lupa.lua51`, so `code-review-graph serve` blows up at startup
+      # (numtide/llm-agents.nix#4497). Upstream restored the versioned
+      # backends in NixOS/nixpkgs#514692 / #514916; drop this override once
+      # our nixpkgs pin includes those commits
+      # (tracking: numtide/llm-agents.nix#4509).
+      lupa = prev.lupa.overridePythonAttrs (old: {
+        src = old.src.override {
+          fetchSubmodules = true;
+          hash = "sha256-XLBUQ1TrzWWST9RJdMTnpsceldDNzidnL82bixLhSRA=";
+        };
+        env = { };
+        nativeBuildInputs = [ ];
+        buildInputs = [ ];
+        pythonImportsCheck = (old.pythonImportsCheck or [ ]) ++ [ "lupa.lua51" ];
+      });
     };
   };
 
@@ -51,7 +70,13 @@ python.pkgs.buildPythonApplication rec {
     "watchdog"
   ];
 
-  pythonImportsCheck = [ "code_review_graph" ];
+  pythonImportsCheck = [
+    "code_review_graph"
+    # Regression test for numtide/llm-agents.nix#4497: the `serve` command
+    # pulls in fakeredis' Lua scripting support, which requires lupa to ship
+    # the version-suffixed `lupa.lua51` backend module.
+    "fakeredis.commands_mixins.scripting_mixin"
+  ];
 
   passthru.category = "Code Review";
 


### PR DESCRIPTION
## Summar

`serve` crashed at startup with `ModuleNotFoundError: No module named 'lupa.lua51'`. The pinned nixpkgs builds `lupa` with `LUPA_NO_BUNDLE` against system luajit, yielding only a `lupa.lua` module, while `fakeredis` (via fastmcp → pydocket) hard-codes `lupa.lua51`. Override `lupa` to build the bundled Lua sources (mirroring NixOS/nixpkgs#514692) and add `fakeredis.commands_mixins.scripting_mixin` to `pythonImportsCheck` as a regression guard. Removal tracked in #4509.

Fixes #4497

## Test plan

- [x] `nix build .#packages.{x86_64-linux,aarch64-linux,aarch64-darwin}.code-review-graph` succeeds; `pythonImportsCheck` reproduced the failure before the override and passes after
- [x] `nix build .#packages.aarch64-darwin.codex` succeeds (previously failed at link)
- [ ] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.