### PR TITLE
agentsview: 0.25.0 -> 0.26.1, restore updater

### DIFF
--- a/packages/agentsview/hashes.json
+++ b/packages/agentsview/hashes.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.25.0",
-  "hash": "sha256-rPb4qgoN0kFK4BG/eWe2ii1MwAKGAimci+esyyVSBrQ=",
-  "npmDepsHash": "sha256-mTm/JaQENbEnz/0pyqPCqhaS3b02DoEj+Zf6wVNiIyU=",
-  "vendorHash": "sha256-Lxyl5TMwJuezFH1eMQC3HHPKplGYCcfDCx4X3VrAAAw="
+  "version": "0.26.1",
+  "hash": "sha256-6vyXnX2DCtZuNhI5hd628PaReHJ5JBimwiYE5jcisyw=",
+  "npmDepsHash": "sha256-T3vPPVAMfJ9C2KsCCaTj/htCbkTHGS9VG3iKT59DKxE=",
+  "vendorHash": "sha256-mSr0ilHGT5rvL4R7EZS92AtotpmR4pKy/NWHopGCTBM="
 }

--- a/packages/agentsview/update.py
+++ b/packages/agentsview/update.py
@@ -1,8 +1,76 @@
-#!/usr/bin/env python3
-"""Prevent automated agentsview bumps while 0.26.0 suffers a frontend regression.
+#!/usr/bin/env nix
+#! nix shell --inputs-from .# nixpkgs#python3 --command python3
 
-Restore the original updater by reverting this file (see git history) once
-wesm/agentsview#428 is fixed.
-"""
+"""Update script for agentsview package."""
 
-print("Skipping agentsview update: pinned to 0.25.0 due to upstream regression.")
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+
+from updater import (
+    calculate_dependency_hash,
+    calculate_url_hash,
+    fetch_github_latest_release,
+    load_hashes,
+    save_hashes,
+    should_update,
+)
+from updater.hash import DUMMY_SHA256_HASH
+from updater.nix import NixCommandError
+
+HASHES_FILE = Path(__file__).parent / "hashes.json"
+
+
+def main() -> None:
+    """Update the agentsview package."""
+    data = load_hashes(HASHES_FILE)
+    current = data["version"]
+    latest = fetch_github_latest_release("wesm", "agentsview")
+
+    print(f"Current: {current}, Latest: {latest}")
+
+    if not should_update(current, latest):
+        print("Already up to date")
+        return
+
+    url = f"https://github.com/wesm/agentsview/archive/refs/tags/v{latest}.tar.gz"
+
+    print("Calculating source hash...")
+    source_hash = calculate_url_hash(url, unpack=True)
+
+    data = {
+        "version": latest,
+        "hash": source_hash,
+        "npmDepsHash": DUMMY_SHA256_HASH,
+        "vendorHash": DUMMY_SHA256_HASH,
+    }
+    save_hashes(HASHES_FILE, data)
+
+    try:
+        print("Calculating npmDepsHash...")
+        npm_deps_hash = calculate_dependency_hash(
+            ".#agentsview", "npmDepsHash", HASHES_FILE, data
+        )
+        data["npmDepsHash"] = npm_deps_hash
+        save_hashes(HASHES_FILE, data)
+    except (ValueError, NixCommandError) as e:
+        print(f"Error calculating npmDepsHash: {e}")
+        return
+
+    try:
+        print("Calculating vendorHash...")
+        vendor_hash = calculate_dependency_hash(
+            ".#agentsview", "vendorHash", HASHES_FILE, data
+        )
+        data["vendorHash"] = vendor_hash
+        save_hashes(HASHES_FILE, data)
+    except (ValueError, NixCommandError) as e:
+        print(f"Error calculating vendorHash: {e}")
+        return
+
+    print(f"Updated to {latest}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The 0.26.0 frontend regression (empty session view, broken sidebar pagination) tracked in wesm/agentsview#428 has been fixed upstream and shipped in v0.26.1, so the temporary pin and stub update.py from #4477 are no longer needed.

Restore the original update.py from before 543be023 and run it to bump to 0.26.1.

Fixes #4485

## Summary

<!-- Briefly describe what this PR does -->

## Test plan

<!-- How did you test this change? -->

- [ ] `nix build .#<package>` succeeds
- [ ] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
