### PR TITLE
free-coding-models: init at 0.3.55

### DIFF
--- a/packages/free-coding-models/default.nix
+++ b/packages/free-coding-models/default.nix
@@ -1,0 +1,8 @@
+{
+  pkgs,
+  flake,
+  ...
+}:
+pkgs.callPackage ./package.nix {
+  inherit flake;
+}

--- a/packages/free-coding-models/package.nix
+++ b/packages/free-coding-models/package.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  flake,
+  stdenv,
+  fetchFromGitHub,
+  fetchurl,
+  nodejs,
+  makeWrapper,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "free-coding-models";
+  version = "0.3.55";
+
+  src = fetchFromGitHub {
+    owner = "vava-nessa";
+    repo = "free-coding-models";
+    rev = "v${version}";
+    hash = "sha256-gjBJP8GizG/VrcY8XFVUvVilGOV155LbFEt/PcO5/I0=";
+  };
+
+  chalk = fetchurl {
+    url = "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz";
+    hash = "sha256-lJV3FaSDqjudtgyPItVJgifYAlxAf5gu74HjTzdXT/0=";
+  };
+
+  nativeBuildInputs = [
+    nodejs
+    makeWrapper
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/node_modules/free-coding-models
+    mkdir -p $out/bin
+
+    cp -r bin src web sources.js patch-openclaw.js patch-openclaw-models.js package.json CHANGELOG.md LICENSE README.md $out/lib/node_modules/free-coding-models/
+
+    mkdir -p $out/lib/node_modules/free-coding-models/node_modules/chalk
+    tar -xzf ${chalk} -C $out/lib/node_modules/free-coding-models/node_modules/chalk --strip-components=1
+
+    makeWrapper ${lib.getExe nodejs} $out/bin/free-coding-models \
+      --add-flags "$out/lib/node_modules/free-coding-models/bin/free-coding-models.js"
+
+    runHook postInstall
+  '';
+
+  dontBuild = true;
+
+  doInstallCheck = false;
+
+  passthru.category = "Utilities";
+
+  meta = {
+    description = "Find the fastest coding LLM models in seconds";
+    homepage = "https://github.com/vava-nessa/free-coding-models";
+    changelog = "https://github.com/vava-nessa/free-coding-models/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    maintainers = with flake.lib.maintainers; [ djsnipa1 ];
+    mainProgram = "free-coding-models";
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
Add package for free-coding-models CLI tool - find the fastest coding LLM models in seconds by pinging free models from multiple providers.

Files created:
- packages/free-coding-models/default.nix
- packages/free-coding-models/package.nix

The package fetches the GitHub source and manually fetches its single runtime dependency (chalk 5.6.2) from npm. A wrapper script is created to run the CLI tool with Node.js.

Category: Utilities

## Summary

<!-- Briefly describe what this PR does -->

## Test plan

<!-- How did you test this change? -->

- [ ] `nix build .#<package>` succeeds
- [ ] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
