### PR TITLE
vibe-kanban: 0.1.2 -> 0.1.44 + package.nix layout fix

### DIFF
--- a/packages/vibe-kanban/hashes.json
+++ b/packages/vibe-kanban/hashes.json
@@ -1,8 +1,8 @@
 {
-  "version": "0.1.2",
-  "tag": "v0.1.2-20260203101746",
-  "hash": "sha256-rC9r9UPkI75vf4Fk1snBz5KDf/U8lw6XrO2nF8gplpo=",
-  "cargoHash": "sha256-IIpLTlHfDhMTwaUwNEGECQXnsWmPpibt6FkO8smrnBA=",
-  "npmDepsHash": "sha256-wY/ATOO3OcUc72ScmHradTnwBG7PZOqIFrTdHSAAY+8=",
-  "releaseZipHash": "sha256-dDoRqox1WQF6zqUJg859/1USpEEQ/uLlPO5Q6DQmfyg="
+  "version": "0.1.44",
+  "tag": "v0.1.44-20260424091429",
+  "hash": "sha256-PNfk8spdjxg2TAaA6g83YJPugH2O5UirrjJIJ1GVoeo=",
+  "cargoHash": "sha256-P0sByQn9vK/Sm/ImiNCRtAJC6lG0M8ZqjxZFAJ4EiZ8=",
+  "npmDepsHash": "sha256-wRJCTDvl6ThpQtV9DbJSyv3o2LEaYN9ZM1nricqaGaQ=",
+  "releaseZipHash": "sha256-lMqN0w0EldusDHtuimAhogXBln9/GEmAFONT/IwYwqk="
 }

--- a/packages/vibe-kanban/package.nix
+++ b/packages/vibe-kanban/package.nix
@@ -75,7 +75,10 @@ let
           | cut -d'"' -f2
       )
 
-      cd frontend
+      # v0.1.44+ moved the desktop UI into a pnpm workspace package at
+      # packages/local-web. crates/server/src/routes/frontend.rs embeds
+      # `../../packages/local-web/dist` via rust-embed.
+      cd packages/local-web
       pnpm build
       runHook postBuild
     '';
@@ -99,6 +102,8 @@ rustPlatform.buildRustPackage {
     "server"
     "--package"
     "review"
+    "--package"
+    "mcp"
   ];
 
   nativeBuildInputs = [
@@ -111,22 +116,30 @@ rustPlatform.buildRustPackage {
     sqlite
   ];
 
-  # Copy frontend assets before Rust build
+  # Copy frontend assets before Rust build. crates/server embeds
+  # ../../packages/local-web/dist via rust-embed, so the path the binary
+  # expects must be populated before cargo runs.
   preBuild = ''
-    mkdir -p frontend/dist
-    cp -r ${frontend}/* frontend/dist/
+    mkdir -p packages/local-web/dist
+    cp -r ${frontend}/* packages/local-web/dist/
   '';
 
   env = {
     SQLX_OFFLINE = "true";
     LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
+    # v0.1.44+ pulls in transitive deps that activate openssl-sys'
+    # `vendored` feature, which would compile OpenSSL from source via
+    # the openssl-src crate (needs perl in buildInputs). Force dynamic
+    # linking against the openssl already in buildInputs.
+    OPENSSL_NO_VENDOR = "1";
   };
 
   doCheck = false;
 
   postInstall = ''
     mv $out/bin/server $out/bin/vibe-kanban
-    mv $out/bin/mcp_task_server $out/bin/vibe-kanban-mcp
+    # crates/mcp produces a binary already named `vibe-kanban-mcp`
+    # (was `mcp_task_server` in older releases — no rename needed now).
     mv $out/bin/review $out/bin/vibe-kanban-review
     rm -f $out/bin/generate_types
     rm -rf $out/bin/*.dSYM

--- a/packages/vibe-kanban/update.py
+++ b/packages/vibe-kanban/update.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env nix
+#! nix shell --inputs-from .# nixpkgs#python3 --command python3
+
+"""Update script for vibe-kanban package."""
+
+import json
+import sys
+import urllib.request
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+
+from updater import (
+    calculate_dependency_hash,
+    calculate_url_hash,
+    load_hashes,
+    save_hashes,
+    should_update,
+)
+from updater.hash import DUMMY_SHA256_HASH
+from updater.nix import NixCommandError, nix_prefetch_url
+
+HASHES_FILE = Path(__file__).parent / "hashes.json"
+
+
+def fetch_latest_release_tag(owner: str, repo: str) -> tuple[str, str]:
+    """Return (tag, version) of the latest BloopAI/vibe-kanban release.
+
+    Tags are shaped `v0.1.44-20260424091429`. Strip the leading `v` and the
+    timestamp suffix to derive the upstream semver.
+    """
+    url = f"https://api.github.com/repos/{owner}/{repo}/releases/latest"
+    req = urllib.request.Request(url, headers={"User-Agent": "llm-agents-updater"})
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        data = json.load(resp)
+    tag = data["tag_name"]
+    version = tag.lstrip("v").split("-", 1)[0]
+    return tag, version
+
+
+def main() -> None:
+    """Update the vibe-kanban package."""
+    data = load_hashes(HASHES_FILE)
+    current = data["version"]
+    tag, latest = fetch_latest_release_tag("BloopAI", "vibe-kanban")
+
+    print(f"Current: {current}, Latest: {latest} (tag {tag})")
+
+    if not should_update(current, latest):
+        print("Already up to date")
+        return
+
+    src_url = f"https://github.com/BloopAI/vibe-kanban/archive/refs/tags/{tag}.tar.gz"
+    print("Calculating source hash...")
+    source_hash = calculate_url_hash(src_url, unpack=True)
+
+    release_zip_url = (
+        f"https://github.com/BloopAI/vibe-kanban/releases/download/{tag}/"
+        f"vibe-kanban-{tag}.zip"
+    )
+    print("Calculating release zip hash...")
+    release_zip_hash = nix_prefetch_url(release_zip_url, unpack=False)
+
+    new_data = {
+        "version": latest,
+        "tag": tag,
+        "hash": source_hash,
+        "cargoHash": DUMMY_SHA256_HASH,
+        "npmDepsHash": DUMMY_SHA256_HASH,
+        "releaseZipHash": release_zip_hash,
+    }
+    save_hashes(HASHES_FILE, new_data)
+
+    try:
+        print("Calculating cargoHash...")
+        cargo_hash = calculate_dependency_hash(
+            ".#vibe-kanban", "cargoHash", HASHES_FILE, new_data
+        )
+        new_data["cargoHash"] = cargo_hash
+        save_hashes(HASHES_FILE, new_data)
+
+        print("Calculating npmDepsHash...")
+        npm_deps_hash = calculate_dependency_hash(
+            ".#vibe-kanban", "npmDepsHash", HASHES_FILE, new_data
+        )
+        new_data["npmDepsHash"] = npm_deps_hash
+        save_hashes(HASHES_FILE, new_data)
+    except (ValueError, NixCommandError) as e:
+        print(f"Error: {e}")
+        return
+
+    print(f"Updated to {latest} (tag {tag})")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Stacked on top of #4563 (which adds update.py).

Once #4563 merges, the daily auto-update workflow will run update.py and produce the 0.1.2 -> 0.1.44 hashes.json bump on its own. But that auto-PR will fail nix-build because v0.1.44 reshapes the source tree. This PR carries the package.nix changes needed for v0.1.44 to actually build.

Layout changes vs v0.1.2:

- Frontend moved into a pnpm workspace package at `packages/local-web` (was top-level `frontend/`). Updated buildPhase `cd packages/local-web` and Rust preBuild `mkdir -p packages/local-web/dist`. crates/server/src/routes/frontend.rs uses rust-embed with folder `../../packages/local-web/dist`.
- The mcp binary is now named directly: crates/mcp produces a `[[bin]] name = "vibe-kanban-mcp"` (was `mcp_task_server` then renamed in postInstall). Added `--package mcp` to cargoBuildFlags and dropped the rename in postInstall.
- A transitive dep activates openssl-sys with the `vendored` feature, which would compile OpenSSL from source via openssl-src (needs perl). Set `OPENSSL_NO_VENDOR=1` so the build links dynamically against the openssl already in buildInputs.

Local nix-build is green; all three binaries (vibe-kanban 153MB, vibe-kanban-mcp 19MB, vibe-kanban-review 11MB) produce and run.

Marking draft so #4563 lands first; will mark ready immediately after that merges.