### PR TITLE
Update README.md binary cache to match unstable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1118,8 +1118,8 @@ Alternatively, you can configure this system-wide in your NixOS configuration:
 
 ```nix
 nix.settings = {
-  extra-substituters = [ "https://cache.numtide.com" ];
-  extra-trusted-public-keys = [
+  substituters = [ "https://cache.numtide.com" ];
+  trusted-public-keys = [
     "niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g="
   ];
 };


### PR DESCRIPTION
## Summary

extra-substitutors is not a thing in the docs at least - https://search.nixos.org/options?channel=unstable&query=substituters&show=option:nix.settings.trusted-substituters

## Test plan

Nope. Just a readme.md update. 
