### PR TITLE
hermes-agent: ship dashboard web dist

### DIFF
--- a/packages/hermes-agent/package.nix
+++ b/packages/hermes-agent/package.nix
@@ -151,6 +151,29 @@ let
     '';
   };
 
+  # `hermes dashboard` serves a Vite app from hermes_cli/web_dist. Build it
+  # ahead of time and point the wrapper at the immutable output so packaged
+  # installs never try to build frontend assets at runtime.
+  hermes-web = buildNpmPackage {
+    pname = "hermes-web";
+    inherit version;
+    src = "${src}/web";
+    npmDepsHash = "sha256-HWB1piIPglTXbzQHXFYHLgVZIbDb60esupXSQGa1+lI=";
+
+    buildPhase = ''
+      runHook preBuild
+      npm run build -- --outDir "$TMPDIR/web-dist"
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out/share/hermes-web
+      cp -r "$TMPDIR/web-dist"/. $out/share/hermes-web/
+      runHook postInstall
+    '';
+  };
+
   hermesDeps =
     with python3.pkgs;
     [
@@ -252,6 +275,9 @@ python3.pkgs.buildPythonApplication {
     "HERMES_TUI_DIR"
     "${hermes-tui}/lib/hermes-tui"
     "--set"
+    "HERMES_WEB_DIST"
+    "${hermes-web}/share/hermes-web"
+    "--set"
     "HERMES_PYTHON"
     "${pythonEnv}/bin/python3"
     "--set"
@@ -291,14 +317,16 @@ python3.pkgs.buildPythonApplication {
   # #4364: wrapper must wire up the TUI and a deps-capable gateway python.
   postInstallCheck = ''
     grep -q HERMES_TUI_DIR $out/bin/hermes
+    grep -q HERMES_WEB_DIST $out/bin/hermes
     grep -q HERMES_PYTHON $out/bin/hermes
     test -f ${hermes-tui}/lib/hermes-tui/dist/entry.js
+    test -f ${hermes-web}/share/hermes-web/index.html
     ${pythonEnv}/bin/python3 -c 'import dotenv, tenacity, openai'
   '';
 
   passthru = {
     category = "AI Assistants";
-    inherit hermes-tui;
+    inherit hermes-tui hermes-web;
   };
 
   meta = with lib; {


### PR DESCRIPTION

## Summary

Build and install Hermes dashboard frontend assets as a separate `hermes-web`
derivation, then export `HERMES_WEB_DIST` from the packaged wrapper.

This fixes packaged `hermes dashboard` instances that currently return
`Frontend not built. Run: cd web && npm run build` because the immutable Nix
output does not include `hermes_cli/web_dist`.

Related context: I checked `NixOS/nixpkgs` for an equivalent `hermes-agent`
packaging change and did not find one to reference. The closest prior art I
found is the dashboard packaging breakage and workaround described in
`NousResearch/hermes-agent#9305`.

## Test plan

- `nix build --accept-flake-config .#hermes-agent`
- `./result/bin/hermes dashboard --host 127.0.0.1 --port 19119 --no-open`
- `curl http://127.0.0.1:19119` returns the dashboard HTML instead of the
  frontend-not-built JSON error
- [x] `nix build .#<package>` succeeds
- [ ] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
