### PR TITLE
vibe-kanban: 0.1.2 -> 0.1.44

### DIFF
--- a/packages/vibe-kanban/hashes.json
+++ b/packages/vibe-kanban/hashes.json
@@ -1,8 +1,8 @@
 {
-  "version": "0.1.2",
-  "tag": "v0.1.2-20260203101746",
-  "hash": "sha256-rC9r9UPkI75vf4Fk1snBz5KDf/U8lw6XrO2nF8gplpo=",
-  "cargoHash": "sha256-IIpLTlHfDhMTwaUwNEGECQXnsWmPpibt6FkO8smrnBA=",
-  "npmDepsHash": "sha256-wY/ATOO3OcUc72ScmHradTnwBG7PZOqIFrTdHSAAY+8=",
-  "releaseZipHash": "sha256-dDoRqox1WQF6zqUJg859/1USpEEQ/uLlPO5Q6DQmfyg="
+  "version": "0.1.44",
+  "tag": "v0.1.44-20260424091429",
+  "hash": "sha256-PNfk8spdjxg2TAaA6g83YJPugH2O5UirrjJIJ1GVoeo=",
+  "cargoHash": "sha256-P0sByQn9vK/Sm/ImiNCRtAJC6lG0M8ZqjxZFAJ4EiZ8=",
+  "npmDepsHash": "sha256-wRJCTDvl6ThpQtV9DbJSyv3o2LEaYN9ZM1nricqaGaQ=",
+  "releaseZipHash": "sha256-lMqN0w0EldusDHtuimAhogXBln9/GEmAFONT/IwYwqk="
 }

--- a/packages/vibe-kanban/package.nix
+++ b/packages/vibe-kanban/package.nix
@@ -14,6 +14,7 @@
   libgit2,
   sqlite,
   llvmPackages,
+  perl,
 }:
 
 let
@@ -69,21 +70,23 @@ let
       # Extract the react-virtuoso license key from upstream's pre-built
       # release assets rather than storing it in our repository.
       export VITE_PUBLIC_REACT_VIRTUOSO_LICENSE_KEY=$(
-        unzip -p ${releaseZip} '*/assets/index-*.js' \
+        unzip -p ${releaseZip} '*/dist/assets/index-*.js' \
           | grep -o 'licenseKey:"[^"]*"' \
           | head -1 \
           | cut -d'"' -f2
       )
 
-      cd frontend
-      pnpm build
+      # 0.1.44 reshapes the source tree into a pnpm workspace under
+      # `packages/`. The local browser frontend (formerly `frontend/`)
+      # now lives at `packages/local-web/` as the @vibe/local-web package.
+      pnpm --filter @vibe/local-web build
       runHook postBuild
     '';
 
     installPhase = ''
       runHook preInstall
       mkdir -p $out
-      cp -r dist/* $out/
+      cp -r packages/local-web/dist/* $out/
       runHook postInstall
     '';
   };
@@ -98,12 +101,18 @@ rustPlatform.buildRustPackage {
     "--package"
     "server"
     "--package"
+    "mcp"
+    "--package"
     "review"
   ];
 
   nativeBuildInputs = [
     pkg-config
     llvmPackages.libclang
+    # crates/executors enables openssl's `vendored` feature for musl
+    # cross-compile builds, which forces a from-source openssl build that
+    # needs perl regardless of the host openssl present in buildInputs.
+    perl
   ];
   buildInputs = [
     openssl
@@ -111,10 +120,11 @@ rustPlatform.buildRustPackage {
     sqlite
   ];
 
-  # Copy frontend assets before Rust build
+  # Copy frontend assets before Rust build. crates/server's build.rs and
+  # rust_embed both reference `../../packages/local-web/dist`.
   preBuild = ''
-    mkdir -p frontend/dist
-    cp -r ${frontend}/* frontend/dist/
+    mkdir -p packages/local-web/dist
+    cp -r ${frontend}/* packages/local-web/dist/
   '';
 
   env = {
@@ -125,8 +135,9 @@ rustPlatform.buildRustPackage {
   doCheck = false;
 
   postInstall = ''
+    # Upstream's `mcp` crate already declares its bin as `vibe-kanban-mcp`
+    # in 0.1.44; only `server` and `review` still need renaming.
     mv $out/bin/server $out/bin/vibe-kanban
-    mv $out/bin/mcp_task_server $out/bin/vibe-kanban-mcp
     mv $out/bin/review $out/bin/vibe-kanban-review
     rm -f $out/bin/generate_types
     rm -rf $out/bin/*.dSYM

--- a/packages/vibe-kanban/update.py
+++ b/packages/vibe-kanban/update.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env nix
+#! nix shell --inputs-from .# nixpkgs#python3 --command python3
+
+"""Update script for vibe-kanban package.
+
+vibe-kanban is the rare GitHub project where the release tag carries a
+timestamp suffix (`v0.1.44-20260424091429`). nix-update can't parse
+that, and the package layers a second prebuilt-zip asset on top of the
+normal source + cargoHash + npmDepsHash for a baked-in react-virtuoso
+licence key, so we drive the update through hashes.json by hand.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+
+from updater import (
+    calculate_dependency_hash,
+    calculate_url_hash,
+    fetch_json,
+    load_hashes,
+    save_hashes,
+    should_update,
+)
+from updater.hash import DUMMY_SHA256_HASH
+from updater.nix import NixCommandError
+
+HASHES_FILE = Path(__file__).parent / "hashes.json"
+OWNER = "BloopAI"
+REPO = "vibe-kanban"
+
+
+def fetch_latest_tag() -> tuple[str, str]:
+    """Return (tag, semver) of the latest release.
+
+    Tags look like `v0.1.44-20260424091429`; strip the `v` and timestamp
+    suffix to derive the semver used as `version`.
+    """
+    data = fetch_json(f"https://api.github.com/repos/{OWNER}/{REPO}/releases/latest")
+    if not isinstance(data, dict):
+        msg = f"Expected dict from GitHub API, got {type(data)}"
+        raise TypeError(msg)
+    tag: str = data["tag_name"]
+    return tag, tag.lstrip("v").split("-", 1)[0]
+
+
+def main() -> None:
+    """Update vibe-kanban hashes to the latest BloopAI release."""
+    data = load_hashes(HASHES_FILE)
+    tag, latest = fetch_latest_tag()
+    print(f"Current: {data['version']}, Latest: {latest} (tag {tag})")
+    if not should_update(data["version"], latest):
+        print("Already up to date")
+        return
+
+    src_url = f"https://github.com/{OWNER}/{REPO}/archive/refs/tags/{tag}.tar.gz"
+    zip_url = f"https://github.com/{OWNER}/{REPO}/releases/download/{tag}/vibe-kanban-{tag}.zip"
+
+    new_data = {
+        "version": latest,
+        "tag": tag,
+        "hash": calculate_url_hash(src_url, unpack=True),
+        "cargoHash": DUMMY_SHA256_HASH,
+        "npmDepsHash": DUMMY_SHA256_HASH,
+        "releaseZipHash": calculate_url_hash(zip_url, unpack=False),
+    }
+    save_hashes(HASHES_FILE, new_data)
+
+    # cargoHash and npmDepsHash both fall out of FOD build failures, so
+    # let calculate_dependency_hash trigger them sequentially.
+    try:
+        for key in ("cargoHash", "npmDepsHash"):
+            print(f"Calculating {key}...")
+            new_data[key] = calculate_dependency_hash(
+                ".#vibe-kanban", key, HASHES_FILE, new_data
+            )
+            save_hashes(HASHES_FILE, new_data)
+    except (ValueError, NixCommandError) as e:
+        print(f"Error: {e}")
+        sys.exit(1)
+
+    print(f"Updated to {latest} (tag {tag})")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Bumps vibe-kanban to 0.1.44, picking up the structural rework noted in #4563.

## Source-tree changes

Upstream reshaped the repo into a pnpm workspace under `packages/` in 0.1.44:

- The local browser frontend moved from `frontend/` to `packages/local-web/` (as the `@vibe/local-web` workspace package). `crates/server`'s `build.rs` and `rust_embed` now reference `../../packages/local-web/dist` directly, so the Nix copy step had to follow.
- The `mcp` crate now declares its binary as `vibe-kanban-mcp` (was `mcp_task_server`), and is no longer pulled in transitively by `server` — added `--package mcp` to `cargoBuildFlags` and dropped the `mcp_task_server` rename in `postInstall`.
- The release zip's licence-key bundle moved one directory deeper (`*/dist/assets/` instead of `*/assets/`), so the extraction glob needed updating in lock-step.

## openssl perl dep

`crates/executors` now enables openssl's `vendored` feature on Linux to keep musl cross-compile builds working, which forces a from-source openssl build that needs perl regardless of the system openssl already present in `buildInputs`. Added `perl` to `nativeBuildInputs` with a comment explaining why.

## Update script

#4563 added a working `update.py` (used to produce these hashes); merging that first and then this on top is the cleanest sequence, but this branch carries the regenerated `hashes.json` regardless.

## Testing

```
nix build .#vibe-kanban
```

Builds locally on x86_64-linux. All three binaries start successfully:

- `vibe-kanban` (server) — boots, creates default config
- `vibe-kanban-mcp` — starts
- `vibe-kanban-review` — starts