### PR TITLE
pi: update npm package to new scope

### DIFF
--- a/packages/pi/hashes.json
+++ b/packages/pi/hashes.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.73.1",
-  "sourceHash": "sha256-e/XUkmcMBP18WZ3ufm6qv/lkCEr/0hZ2YQfmdB33ouE=",
-  "npmDepsHash": "sha256-Ea5aLEk9QZONSN65OLIPQrYc3G79vPhLuyajKAx2Qik="
+  "version": "0.74.0",
+  "sourceHash": "sha256-l0pzuWGVvX1jDhFYaey14N16XDo47kkm3JlEhmPUo0Q=",
+  "npmDepsHash": "sha256-KQsuZzH8bdnvyD/ZcSIZyDPO4th6+osbXFZmaK21eOc="
 }

--- a/packages/pi/package-lock.json
+++ b/packages/pi/package-lock.json
@@ -1,17 +1,17 @@
 {
-	"name": "@mariozechner/pi-coding-agent",
-	"version": "0.73.1",
+	"name": "@earendil-works/pi-coding-agent",
+	"version": "0.74.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "@mariozechner/pi-coding-agent",
-			"version": "0.73.1",
+			"name": "@earendil-works/pi-coding-agent",
+			"version": "0.74.0",
 			"license": "MIT",
 			"dependencies": {
-				"@mariozechner/pi-agent-core": "^0.73.1",
-				"@mariozechner/pi-ai": "^0.73.1",
-				"@mariozechner/pi-tui": "^0.73.1",
+				"@earendil-works/pi-agent-core": "^0.74.0",
+				"@earendil-works/pi-ai": "^0.74.0",
+				"@earendil-works/pi-tui": "^0.74.0",
 				"@silvia-odwyer/photon-node": "^0.3.4",
 				"chalk": "^5.5.0",
 				"cli-highlight": "^2.1.11",
@@ -211,9 +211,9 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-bedrock-runtime": {
-			"version": "3.1044.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1044.0.tgz",
-			"integrity": "sha512-uwJB0pVZIey+kYag8xeUirMvuaDhhEHuYgSsapOKT5XCAije5pLNlg160eECJdhX9JEf0IthIM3IiHKSEkFtMw==",
+			"version": "3.1045.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1045.0.tgz",
+			"integrity": "sha512-aPC6gAz9uKRiwfnKB7peTs6yD0FpSzmVnSkx0f2QtJfosFM6J6KtBvR1lMKby050K4C4PAyEScwA5YTsGfTcGA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
@@ -228,7 +228,7 @@
 				"@aws-sdk/middleware-user-agent": "^3.972.38",
 				"@aws-sdk/middleware-websocket": "^3.972.16",
 				"@aws-sdk/region-config-resolver": "^3.972.13",
-				"@aws-sdk/token-providers": "3.1044.0",
+				"@aws-sdk/token-providers": "3.1045.0",
 				"@aws-sdk/types": "^3.973.8",
 				"@aws-sdk/util-endpoints": "^3.996.8",
 				"@aws-sdk/util-user-agent-browser": "^3.972.10",
@@ -695,9 +695,9 @@
 			}
 		},
 		"node_modules/@aws-sdk/token-providers": {
-			"version": "3.1044.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1044.0.tgz",
-			"integrity": "sha512-uvpWTfpzOM9qVrR0kdAjzBbvv2ERW7S1CKeBeRkHyHy21Ext5fNReIVrbAzhjuVC7UxRyZQ8PHYW/3T83hWlbg==",
+			"version": "3.1045.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1045.0.tgz",
+			"integrity": "sha512-/o4qcty0DmQola0DBniRVeBakYY6ALOvKEFo1AtJpTmMn/cJ+Fk3RWGe5ieT/f/eYbHG9k5E7poKge/E+WGv4Q==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/core": "^3.974.8",
@@ -858,6 +858,63 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
+		"node_modules/@earendil-works/pi-agent-core": {
+			"version": "0.74.0",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.74.0.tgz",
+			"integrity": "sha512-6GMR7/wwjEJ1EsXLWEz03QOWin4AMrJ/AZoMpgm5DJ6GHsF6q6GOhQbj5Zip4dow3vo/TmBAVqM+vmGfrjGAFQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@earendil-works/pi-ai": "^0.74.0",
+				"typebox": "^1.1.24"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-ai": {
+			"version": "0.74.0",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.74.0.tgz",
+			"integrity": "sha512-7M7qcrZY/KEkH4wFkX3eqzvmKru4O88wezNKoN0KD2m4aAOmp9tdW2xCmUgSTSWlKB7b2Xw9QtAgrzHtg6t6iw==",
+			"license": "MIT",
+			"dependencies": {
+				"@anthropic-ai/sdk": "^0.91.1",
+				"@aws-sdk/client-bedrock-runtime": "^3.1030.0",
+				"@google/genai": "^1.40.0",
+				"@mistralai/mistralai": "^2.2.0",
+				"chalk": "^5.6.2",
+				"openai": "6.26.0",
+				"partial-json": "^0.1.7",
+				"proxy-agent": "^6.5.0",
+				"typebox": "^1.1.24",
+				"undici": "^7.19.1",
+				"zod-to-json-schema": "^3.24.6"
+			},
+			"bin": {
+				"pi-ai": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-tui": {
+			"version": "0.74.0",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.74.0.tgz",
+			"integrity": "sha512-1aIfXZp7D/z+1VlZX8BZcs6pgO8rjmil7kwyhctNDsWvce3Yfl8GVgu4eq+I0Mjhr8Cj+ipBiv9CLIzdoyCOIQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mime-types": "^2.1.4",
+				"chalk": "^5.5.0",
+				"get-east-asian-width": "^1.3.0",
+				"marked": "^15.0.12",
+				"mime-types": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			},
+			"optionalDependencies": {
+				"koffi": "^2.9.0"
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
@@ -1525,66 +1582,6 @@
 			],
 			"engines": {
 				"node": ">= 10"
-			}
-		},
-		"node_modules/@mariozechner/pi-agent-core": {
-			"version": "0.73.1",
-			"resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.73.1.tgz",
-			"integrity": "sha512-Y/KVOhuKSgRQgYBlwmRtO2gPkUcoavOSqGF9bpQIINvNZvc19k6Z1H3bFDTce3Vp5ApMmTsfLH3+tNvOg75fAQ==",
-			"deprecated": "please use @earendil-works/pi-agent-core instead going forward",
-			"license": "MIT",
-			"dependencies": {
-				"@mariozechner/pi-ai": "^0.73.1",
-				"typebox": "^1.1.24"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@mariozechner/pi-ai": {
-			"version": "0.73.1",
-			"resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.73.1.tgz",
-			"integrity": "sha512-Jh4lXawZYuC83HzSIYuVum9NBqJD49i4JOt3H96cGW/924cwJMOyUs1Mv/e4QPzTXnzrqMoGviNQnvGgSu1LSg==",
-			"deprecated": "please use @earendil-works/pi-ai instead going forward",
-			"license": "MIT",
-			"dependencies": {
-				"@anthropic-ai/sdk": "^0.91.1",
-				"@aws-sdk/client-bedrock-runtime": "^3.1030.0",
-				"@google/genai": "^1.40.0",
-				"@mistralai/mistralai": "^2.2.0",
-				"chalk": "^5.6.2",
-				"openai": "6.26.0",
-				"partial-json": "^0.1.7",
-				"proxy-agent": "^6.5.0",
-				"typebox": "^1.1.24",
-				"undici": "^7.19.1",
-				"zod-to-json-schema": "^3.24.6"
-			},
-			"bin": {
-				"pi-ai": "dist/cli.js"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@mariozechner/pi-tui": {
-			"version": "0.73.1",
-			"resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.73.1.tgz",
-			"integrity": "sha512-ybVsRnUbzQRtbocltJ2OXb2QogrO67N2BlUyKjZz9BHcZYiDJtNkcKQockxDjsVvDc0uBCLDX6iZJoBElBd8fw==",
-			"deprecated": "please use @earendil-works/pi-tui instead going forward",
-			"license": "MIT",
-			"dependencies": {
-				"@types/mime-types": "^2.1.4",
-				"chalk": "^5.5.0",
-				"get-east-asian-width": "^1.3.0",
-				"marked": "^15.0.12",
-				"mime-types": "^3.0.1"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			},
-			"optionalDependencies": {
-				"koffi": "^2.9.0"
 			}
 		},
 		"node_modules/@mistralai/mistralai": {
@@ -2827,9 +2824,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "24.12.2",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
-			"integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+			"version": "24.12.3",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.3.tgz",
+			"integrity": "sha512-8oljBDGun9cIsZRJR6fkihn0TSXJI0UDOOhncYaERq6M0JMDoPLxyscwruJcb4GKS6dvK/d8xebYBg27h/duaQ==",
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~7.16.0"

--- a/packages/pi/package.nix
+++ b/packages/pi/package.nix
@@ -18,7 +18,7 @@ let
     mkdir -p $out
     tar -xzf ${
       fetchurl {
-        url = "https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/pi-coding-agent-${version}.tgz";
+        url = "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-${version}.tgz";
         hash = versionData.sourceHash;
       }
     } -C $out --strip-components=1

--- a/packages/pi/update.py
+++ b/packages/pi/update.py
@@ -22,7 +22,7 @@ from updater.nix import NixCommandError
 
 SCRIPT_DIR = Path(__file__).parent
 HASHES_FILE = SCRIPT_DIR / "hashes.json"
-NPM_PACKAGE = "@mariozechner/pi-coding-agent"
+NPM_PACKAGE = "@earendil-works/pi-coding-agent"
 
 
 def main() -> None:


### PR DESCRIPTION
fixes #4714

## Summary

Update Pi's npm package scope to new company name.
Updates Pi to 0.74.0

## Test plan

<!-- How did you test this change? -->

- [x] `nix build .#<package>` succeeds
- [x] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
