### PR TITLE
lean-ctx: init at 3.5.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -923,6 +923,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>lean-ctx</strong> - Context Runtime for AI Agents with CCP + TDD. Shell Hook + MCP Server. 57 MCP tools, 10 read modes, 95+ shell patterns, cross-session memory</summary>
+
+- **Source**: source
+- **License**: Apache-2.0
+- **Homepage**: https://leanctx.com
+- **Usage**: `nix run github:numtide/llm-agents.nix#lean-ctx -- --help`
+- **Nix**: [packages/lean-ctx/package.nix](packages/lean-ctx/package.nix)
+
+</details>
+<details>
 <summary><strong>mcporter</strong> - TypeScript runtime and CLI for the Model Context Protocol</summary>
 
 - **Source**: source

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -117,7 +117,6 @@ inputs.nixpkgs.lib.extend (
         githubId = 5122800;
         name = "pikdum";
       };
-      
     };
   }
 )

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -117,11 +117,7 @@ inputs.nixpkgs.lib.extend (
         githubId = 5122800;
         name = "pikdum";
       };
-      antono = {
-        github = "antono";
-        githubId = 7622;
-        name = "Antono";
-      };
+      
     };
   }
 )

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -117,6 +117,11 @@ inputs.nixpkgs.lib.extend (
         githubId = 5122800;
         name = "pikdum";
       };
+      antono = {
+        github = "antono";
+        githubId = 7622;
+        name = "Antono";
+      };
     };
   }
 )

--- a/packages/lean-ctx/default.nix
+++ b/packages/lean-ctx/default.nix
@@ -1,0 +1,8 @@
+{
+  pkgs,
+  perSystem,
+  ...
+}:
+pkgs.callPackage ./package.nix {
+  inherit (perSystem.self) versionCheckHomeHook;
+}

--- a/packages/lean-ctx/default.nix
+++ b/packages/lean-ctx/default.nix
@@ -1,8 +1,10 @@
 {
   pkgs,
   perSystem,
+  flake,
   ...
 }:
 pkgs.callPackage ./package.nix {
   inherit (perSystem.self) versionCheckHomeHook;
+  inherit flake;
 }

--- a/packages/lean-ctx/package.nix
+++ b/packages/lean-ctx/package.nix
@@ -4,6 +4,7 @@
   rustPlatform,
   versionCheckHook,
   versionCheckHomeHook,
+  flake,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -53,7 +54,10 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/yvgude/lean-ctx/releases/tag/v${version}";
     license = licenses.asl20;
     sourceProvenance = with sourceTypes; [ fromSource ];
-    maintainers = with maintainers; [ ];
+    # Use the shared maintainers set from nixpkgs/flake to reference existing
+    # maintainers (do not add a local definition). antono is a maintainer in
+    # the upstream nixpkgs maintainers list, reference it here.
+    maintainers = with flake.lib.maintainers; [ antono ];
     mainProgram = "lean-ctx";
     platforms = platforms.unix;
   };

--- a/packages/lean-ctx/package.nix
+++ b/packages/lean-ctx/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  versionCheckHook,
+  versionCheckHomeHook,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "lean-ctx";
+  version = "3.5.12";
+
+  src = fetchFromGitHub {
+    owner = "yvgude";
+    repo = "lean-ctx";
+    rev = "v${version}";
+    hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+  };
+
+  sourceRoot = "${src.name}/rust";
+
+  cargoHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+
+  # Build with default features: tree-sitter, embeddings, http-server, secure-update
+  # Excluding cloud-server feature as it requires additional database dependencies
+  buildFeatures = [
+    "tree-sitter"
+    "embeddings"
+    "http-server"
+    "secure-update"
+  ];
+
+  doCheck = false;
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    versionCheckHomeHook
+  ];
+
+  passthru.category = "Utilities";
+
+  meta = with lib; {
+    description = "Context Runtime for AI Agents with CCP + TDD. Shell Hook + MCP Server. 57 MCP tools, 10 read modes, 95+ shell patterns, cross-session memory";
+    homepage = "https://leanctx.com";
+    changelog = "https://github.com/yvgude/lean-ctx/releases/tag/v${version}";
+    license = licenses.asl20;
+    sourceProvenance = with sourceTypes; [ fromSource ];
+    maintainers = with maintainers; [ ];
+    mainProgram = "lean-ctx";
+    platforms = platforms.unix;
+  };
+}

--- a/packages/lean-ctx/package.nix
+++ b/packages/lean-ctx/package.nix
@@ -14,12 +14,12 @@ rustPlatform.buildRustPackage rec {
     owner = "yvgude";
     repo = "lean-ctx";
     rev = "v${version}";
-    hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+    hash = "sha256-eYpQjeGnDdvQPShtwrxqbVQHNsizb3xkaUJLkujcEF8=";
   };
 
   sourceRoot = "${src.name}/rust";
 
-  cargoHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+  cargoHash = "sha256-B4AeYHBYneBJc0AKnfTPdKvBUnU+fnkPrv48L+j9XmE=";
 
   # Build with default features: tree-sitter, embeddings, http-server, secure-update
   # Excluding cloud-server feature as it requires additional database dependencies
@@ -31,6 +31,13 @@ rustPlatform.buildRustPackage rec {
   ];
 
   doCheck = false;
+
+  postInstall = ''
+    # Copy skills directory to share
+    mkdir -p $out/share/skills/lean-ctx
+    cp -r $src/skills/lean-ctx/* $out/share/skills/lean-ctx/
+    chmod -R +w $out/share/skills/lean-ctx
+  '';
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [


### PR DESCRIPTION
## Summary

Add the lean-ctx package (v3.5.12) to the flake. This includes the Nix packaging for the lean-ctx binaries, the skills directory shipped under share, and a brief README entry.

## Changes
- packages/lean-ctx/package.nix (package definition)
- packages/lean-ctx/default.nix (wrapper)
- README.md (documentation entry in Utilities section)

 
## Build & Tests

- Formatting:  run before commits.
- Local build:  (fixed an earlier evaluation error by passing  through default.nix).
- CI note: CI check for new packages requires  — this is satisfied by referencing  (antono).
- 
- ## About lean-ctx
- Context runtime that reduces LLM token consumption by compressing and caching developer context.
- Key components: Shell Hook (output compression for common dev tools), MCP Server (56+ tools and multiple read modes), and cross-session memory / context packages.
- Features: semantic caching, dependency & graph-aware context, PR context packs, and usage/savings metrics.
- Typical use cases: long coding sessions, team context sharing, and token-cost reduction for LLM assistants.

## Resources

- Homepage: https://leanctx.com
- Repo: https://github.com/yvgude/lean-ctx