### PR TITLE
ctxo: add MCP server package

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>ctxo</strong> - MCP server delivering dependency-aware, history-enriched context for codebases</summary>
+
+- **Source**: source
+- **License**: MIT
+- **Homepage**: https://github.com/alperhankendi/Ctxo
+- **Usage**: `nix run github:numtide/llm-agents.nix#ctxo -- --help`
+- **Nix**: [packages/ctxo/package.nix](packages/ctxo/package.nix)
+
+</details>
+<details>
 <summary><strong>cursor-agent</strong> - Cursor Agent - CLI tool for Cursor AI code editor</summary>
 
 - **Source**: binary

--- a/packages/ctxo/default.nix
+++ b/packages/ctxo/default.nix
@@ -1,0 +1,3 @@
+{ pkgs, ... }:
+
+pkgs.callPackage ./package.nix { }

--- a/packages/ctxo/package.nix
+++ b/packages/ctxo/package.nix
@@ -1,0 +1,95 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  nodejs,
+  pnpm_10,
+  pnpmConfigHook,
+  makeWrapper,
+  versionCheckHook,
+}:
+
+let
+  pname = "ctxo";
+  version = "0.8.1";
+  pnpmWorkspaces = [ "cli" "plugin-api" "lang-csharp" "lang-go" "lang-typescript" ];
+in
+stdenv.mkDerivation (finalAttrs: {
+  inherit pname version;
+
+  src = fetchFromGitHub {
+    owner = "alperhankendi";
+    repo = "Ctxo";
+    rev = "v${version}";
+    hash = "sha256-+h5UylotoYVfTzd7z65yfLhA/1ZQHQ+6LUFP4PoSxoo=";
+  };
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    inherit pnpmWorkspaces;
+    pnpm = pnpm_10;
+    # pnpmDeps hash observed from a build run
+    hash = "sha256-Hbm1ltx7IfINSe9Mo29GarsS1YFVtIuctCNXzobc2iA=";
+    fetcherVersion = 2;
+  };
+
+  inherit pnpmWorkspaces;
+
+  nativeBuildInputs = [
+    nodejs
+    pnpm_10
+    pnpmConfigHook
+    makeWrapper
+  ];
+
+  # Ensure pnpm's deploy can produce prod layout
+  buildPhase = ''
+    runHook preBuild
+    # Build only the workspace packages required by the CLI to avoid building docs/site
+    pnpm --filter @ctxo/plugin-api build
+    pnpm --filter @ctxo/cli build
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    # Use pnpm deploy to create production layout for the CLI and included workspaces
+    pnpm config set inject-workspace-packages true
+    pnpm --filter @ctxo/cli --prod --ignore-scripts deploy $out/lib/ctxo
+    # Ensure workspace packages are present in the deploy directory
+    if [ -d "$out/lib/ctxo/node_modules/@ctxo/plugin-api" ]; then
+      true
+    else
+      if [ -d "packages/plugin-api/dist" ]; then
+        mkdir -p $out/lib/ctxo/node_modules/@ctxo/plugin-api
+        cp -r packages/plugin-api/dist/* $out/lib/ctxo/node_modules/@ctxo/plugin-api/
+      fi
+    fi
+
+    # Install wrapper binary
+    mkdir -p $out/bin
+    makeWrapper ${nodejs}/bin/node $out/bin/ctxo \
+      --add-flags $out/lib/ctxo/dist/index.js \
+      --prefix PATH : ${lib.makeBinPath [ nodejs ]}
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru = { category = "AI Coding Agents"; };
+
+  meta = {
+    description = "MCP server delivering dependency-aware, history-enriched context for codebases";
+    homepage = "https://github.com/alperhankendi/Ctxo";
+    changelog = "https://github.com/alperhankendi/Ctxo/releases";
+    license = lib.licenses.mit;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    maintainers = with lib.maintainers; [ antono ];
+    platforms = lib.platforms.all;
+    mainProgram = "ctxo";
+  };
+})

--- a/packages/ctxo/package.nix
+++ b/packages/ctxo/package.nix
@@ -13,7 +13,13 @@
 let
   pname = "ctxo";
   version = "0.8.1";
-  pnpmWorkspaces = [ "cli" "plugin-api" "lang-csharp" "lang-go" "lang-typescript" ];
+  pnpmWorkspaces = [
+    "cli"
+    "plugin-api"
+    "lang-csharp"
+    "lang-go"
+    "lang-typescript"
+  ];
 in
 stdenv.mkDerivation (finalAttrs: {
   inherit pname version;
@@ -80,7 +86,9 @@ stdenv.mkDerivation (finalAttrs: {
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
 
-  passthru = { category = "AI Coding Agents"; };
+  passthru = {
+    category = "AI Coding Agents";
+  };
 
   meta = {
     description = "MCP server delivering dependency-aware, history-enriched context for codebases";


### PR DESCRIPTION
Adds a Nix package for ctxo (v0.8.1), an MCP server delivering dependency-aware, history-enriched context for codebases.

- Adds packages/ctxo/package.nix and default.nix
- Updates README with package entry

Build notes: uses pnpm workspace build and deploy; includes versionCheckHook for install checks.