### PR TITLE
claude-code-acp: remove deprecation alias

### DIFF
--- a/packages/claude-code-acp/default.nix
+++ b/packages/claude-code-acp/default.nix
@@ -1,9 +1,0 @@
-{
-  pkgs,
-  perSystem,
-  ...
-}:
-pkgs.lib.warnOnInstantiate "'claude-code-acp' has been renamed to 'claude-agent-acp'. Please update your references." perSystem.self.claude-agent-acp
-// {
-  passthru.hideFromDocs = true;
-}


### PR DESCRIPTION
The alias has been emitting a warnOnInstantiate since the rename to
claude-agent-acp two weeks ago. Drop it now to silence the warning for
all consumers.
