### PR TITLE
codex-auth: init at 0.2.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -833,6 +833,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>codex-auth</strong> - CLI tool for switching Codex accounts</summary>
+
+- **Source**: source
+- **License**: MIT
+- **Homepage**: https://github.com/loongphy/codex-auth
+- **Usage**: `nix run github:numtide/llm-agents.nix#codex-auth -- --help`
+- **Nix**: [packages/codex-auth/package.nix](packages/codex-auth/package.nix)
+
+</details>
+<details>
 <summary><strong>context-hub</strong> - CLI for Context Hub - search and retrieve LLM-optimized docs and skills</summary>
 
 - **Source**: source

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -42,6 +42,11 @@ inputs.nixpkgs.lib.extend (
         githubId = 198010;
         name = "Charles Swanberg";
       };
+      xbpk3t = {
+        github = "xbpk3t";
+        githubId = 8591495;
+        name = "xbpk3t";
+      };
       xorilog = {
         github = "xorilog";
         githubId = 5818406;

--- a/packages/codex-auth/default.nix
+++ b/packages/codex-auth/default.nix
@@ -1,0 +1,8 @@
+{
+  pkgs,
+  flake,
+  ...
+}:
+pkgs.callPackage ./package.nix {
+  inherit flake;
+}

--- a/packages/codex-auth/package.nix
+++ b/packages/codex-auth/package.nix
@@ -9,65 +9,50 @@
   versionCheckHook,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "codex-auth";
   version = "0.2.8";
 
   src = fetchFromGitHub {
     owner = "loongphy";
     repo = "codex-auth";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-J1aq5ieWkHqze4HF/7Lw+VIa+FxO7vmsXaDJc7VH+Wk=";
   };
 
-  # Upstream v0.2.8 does not compile with nixpkgs' default zig 0.16.0.
-  # Pin zig_0_15 to package the latest stable release without carrying a
-  # source compatibility patch.
+  # Upstream v0.2.8 does not compile with nixpkgs' default zig 0.16.0
+  # (`error: discard of capture; omit it instead`). Pin zig_0_15 to package
+  # the latest stable release without carrying a source compatibility patch.
   nativeBuildInputs = [
-    zig_0_15
+    zig_0_15.hook
     makeWrapper
   ];
 
-  dontConfigure = true;
+  zigBuildFlags = [ "-Doptimize=ReleaseSafe" ];
 
-  buildPhase = ''
-    runHook preBuild
+  doCheck = true;
 
-    export ZIG_GLOBAL_CACHE_DIR="$TMPDIR/zig-global-cache"
-    export ZIG_LOCAL_CACHE_DIR="$PWD/.zig-cache"
-    mkdir -p "$ZIG_GLOBAL_CACHE_DIR" "$ZIG_LOCAL_CACHE_DIR"
-
-    zig build -Doptimize=ReleaseSafe
-
-    runHook postBuild
-  '';
-
-  installPhase = ''
-    runHook preInstall
-
-    mkdir -p $out/bin
-    install -Dm755 zig-out/bin/codex-auth $out/bin/codex-auth
-
+  # codex-auth shells out to Node.js for ChatGPT HTTP/usage queries
+  # (CODEX_AUTH_NODE_EXECUTABLE in src/api/http_types.zig). Pin it so the
+  # tool works without a system Node install.
+  postInstall = ''
     wrapProgram $out/bin/codex-auth \
       --set CODEX_AUTH_NODE_EXECUTABLE ${lib.getExe nodejs}
-
-    runHook postInstall
   '';
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgramArg = [ "--version" ];
 
   passthru.category = "Utilities";
 
   meta = with lib; {
     description = "CLI tool for switching Codex accounts";
     homepage = "https://github.com/loongphy/codex-auth";
-    changelog = "https://github.com/loongphy/codex-auth/releases/tag/v${version}";
+    changelog = "https://github.com/loongphy/codex-auth/releases/tag/v${finalAttrs.version}";
     license = licenses.mit;
     sourceProvenance = with sourceTypes; [ fromSource ];
     maintainers = with flake.lib.maintainers; [ xbpk3t ];
     mainProgram = "codex-auth";
     platforms = platforms.unix;
   };
-}
+})

--- a/packages/codex-auth/package.nix
+++ b/packages/codex-auth/package.nix
@@ -1,0 +1,73 @@
+{
+  lib,
+  stdenv,
+  flake,
+  fetchFromGitHub,
+  zig_0_15,
+  makeWrapper,
+  nodejs,
+  versionCheckHook,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "codex-auth";
+  version = "0.2.8";
+
+  src = fetchFromGitHub {
+    owner = "loongphy";
+    repo = "codex-auth";
+    tag = "v${version}";
+    hash = "sha256-J1aq5ieWkHqze4HF/7Lw+VIa+FxO7vmsXaDJc7VH+Wk=";
+  };
+
+  # Upstream v0.2.8 does not compile with nixpkgs' default zig 0.16.0.
+  # Pin zig_0_15 to package the latest stable release without carrying a
+  # source compatibility patch.
+  nativeBuildInputs = [
+    zig_0_15
+    makeWrapper
+  ];
+
+  dontConfigure = true;
+
+  buildPhase = ''
+    runHook preBuild
+
+    export ZIG_GLOBAL_CACHE_DIR="$TMPDIR/zig-global-cache"
+    export ZIG_LOCAL_CACHE_DIR="$PWD/.zig-cache"
+    mkdir -p "$ZIG_GLOBAL_CACHE_DIR" "$ZIG_LOCAL_CACHE_DIR"
+
+    zig build -Doptimize=ReleaseSafe
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    install -Dm755 zig-out/bin/codex-auth $out/bin/codex-auth
+
+    wrapProgram $out/bin/codex-auth \
+      --set CODEX_AUTH_NODE_EXECUTABLE ${lib.getExe nodejs}
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = [ "--version" ];
+
+  passthru.category = "Utilities";
+
+  meta = with lib; {
+    description = "CLI tool for switching Codex accounts";
+    homepage = "https://github.com/loongphy/codex-auth";
+    changelog = "https://github.com/loongphy/codex-auth/releases/tag/v${version}";
+    license = licenses.mit;
+    sourceProvenance = with sourceTypes; [ fromSource ];
+    maintainers = with flake.lib.maintainers; [ xbpk3t ];
+    mainProgram = "codex-auth";
+    platforms = platforms.unix;
+  };
+}


### PR DESCRIPTION
## Summary

Add `codex-auth`, a CLI tool for switching Codex accounts.

This packages the latest stable release `v0.2.8` from GitHub source.
It pins `zig_0_15` because upstream `v0.2.8` does not build with nixpkgs'
default `zig 0.16.0`.

Closes #4805.

## Test plan

- [x] `nix build .#codex-auth` succeeds
- [x] `nix run .#codex-auth -- --version`
- [x] `nix run .#codex-auth -- --help`
- [x] Package updates via `nix-update`

Additional checks run:
- [x] `./scripts/generate-package-docs.py`
- [x] `nix fmt`
- [x] `nix flake check --accept-flake-config`
