### PR TITLE
grok-cli: init at 0.1.210

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>grok-cli</strong> - Grok CLI from xAI</summary>
+
+- **Source**: binary
+- **License**: unfree
+- **Homepage**: https://x.ai/cli
+- **Usage**: `nix run github:numtide/llm-agents.nix#grok-cli -- --help`
+- **Nix**: [packages/grok-cli/package.nix](packages/grok-cli/package.nix)
+
+</details>
+<details>
 <summary><strong>iflow-cli</strong> - AI coding agent for the terminal with free model access via the iFlow platform</summary>
 
 - **Source**: bytecode

--- a/packages/grok-cli/default.nix
+++ b/packages/grok-cli/default.nix
@@ -1,0 +1,8 @@
+{
+  pkgs,
+  perSystem,
+  ...
+}:
+pkgs.callPackage ./package.nix {
+  inherit (perSystem.self) versionCheckHomeHook;
+}

--- a/packages/grok-cli/hashes.json
+++ b/packages/grok-cli/hashes.json
@@ -1,0 +1,8 @@
+{
+  "version": "0.1.210",
+  "hashes": {
+    "aarch64-darwin": "sha256-uQZgdxkLqdZfWGf+LOzVy2pH4toDVVroQb+iMqhWiUQ=",
+    "aarch64-linux": "sha256-zskTsNseNf8XGV4u6MVhPhUITkj4bdK6Jxn23sb2+8I=",
+    "x86_64-linux": "sha256-IowYyhIcRXfB1G/qne1DiCAs0B2MKz0zG1E3RPoGx5k="
+  }
+}

--- a/packages/grok-cli/package.nix
+++ b/packages/grok-cli/package.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  versionCheckHook,
+  versionCheckHomeHook,
+}:
+
+let
+  versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
+  inherit (versionData) version hashes;
+
+  platformMap = {
+    x86_64-linux = "linux-x86_64";
+    aarch64-linux = "linux-aarch64";
+    aarch64-darwin = "macos-aarch64";
+  };
+
+  platform = stdenv.hostPlatform.system;
+  platformSuffix = platformMap.${platform} or (throw "Unsupported system: ${platform}");
+in
+stdenv.mkDerivation {
+  pname = "grok-cli";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://storage.googleapis.com/grok-build-public-artifacts/cli/grok-${version}-${platformSuffix}";
+    hash = hashes.${platform};
+  };
+
+  dontUnpack = true;
+  dontStrip = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 $src $out/bin/grok
+    ln -s $out/bin/grok $out/bin/agent
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    versionCheckHomeHook
+  ];
+  versionCheckProgramArg = "--version";
+
+  passthru.category = "AI Coding Agents";
+
+  meta = with lib; {
+    description = "Grok CLI from xAI";
+    homepage = "https://x.ai/cli";
+    changelog = "https://x.ai/cli";
+    license = licenses.unfree;
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    mainProgram = "grok";
+    maintainers = with maintainers; [ willfish ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "aarch64-darwin"
+    ];
+  };
+}

--- a/packages/grok-cli/update.py
+++ b/packages/grok-cli/update.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env nix
+#! nix shell --inputs-from .# nixpkgs#python3 --command python3
+
+"""Update script for grok-cli package."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+
+from updater import (
+    calculate_platform_hashes,
+    fetch_text,
+    load_hashes,
+    save_hashes,
+    should_update,
+)
+
+HASHES_FILE = Path(__file__).parent / "hashes.json"
+
+PLATFORMS = {
+    "x86_64-linux": "linux-x86_64",
+    "aarch64-linux": "linux-aarch64",
+    "aarch64-darwin": "macos-aarch64",
+}
+
+VERSION_URL = "https://storage.googleapis.com/grok-build-public-artifacts/cli/stable"
+
+
+def main() -> None:
+    """Update grok-cli hashes."""
+    data = load_hashes(HASHES_FILE)
+    current = data["version"]
+    latest = fetch_text(VERSION_URL).strip()
+
+    print(f"Current: {current}, Latest: {latest}")
+
+    if not should_update(current, latest):
+        print("Already up to date")
+        return
+
+    url_template = f"https://storage.googleapis.com/grok-build-public-artifacts/cli/grok-{latest}-{{platform}}"
+    hashes = calculate_platform_hashes(url_template, PLATFORMS)
+
+    save_hashes(HASHES_FILE, {"version": latest, "hashes": hashes})
+    print(f"Updated to {latest}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add `grok-cli`, the Grok CLI from xAI
- Version 0.1.210, prebuilt binaries from upstream GCS artifacts
- Installs `grok` and the upstream-compatible `agent` symlink
- Category: AI Coding Agents
- Platforms: `x86_64-linux`, `aarch64-linux`, `aarch64-darwin`
- Custom `update.py` tracks the upstream stable version endpoint and refreshes per-platform hashes

## Why prebuilt

Upstream publishes the CLI as per-platform native binaries from `https://storage.googleapis.com/grok-build-public-artifacts/cli`. There is no public source release or package registry artifact for `nix-update` to follow, so this package follows the existing binary package pattern used by tools such as `amp`, `droid`, and `cursor-agent`, with `sourceProvenance = binaryNativeCode`.

## Test plan

- [x] `nix fmt`
- [x] `nix build --accept-flake-config .#grok-cli`
- [x] `./result/bin/grok --version` reports `grok 0.1.210`
- [x] `./result/bin/agent --version` reports `grok 0.1.210`
- [x] `./packages/grok-cli/update.py` reports already up to date
- [x] `./scripts/generate-package-docs.py` updates README
- [x] `python3 .github/ci/check_maintainers.py --base-ref origin/main --system x86_64-linux` passes