### PR TITLE
grok: init at 0.1.210

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>grok</strong> - Grok Build, xAI's agentic coding tool</summary>
+
+- **Source**: binary
+- **License**: unfree
+- **Homepage**: https://x.ai
+- **Usage**: `nix run github:numtide/llm-agents.nix#grok -- --help`
+- **Nix**: [packages/grok/package.nix](packages/grok/package.nix)
+
+</details>
+<details>
 <summary><strong>iflow-cli</strong> - AI coding agent for the terminal with free model access via the iFlow platform</summary>
 
 - **Source**: bytecode

--- a/packages/grok/default.nix
+++ b/packages/grok/default.nix
@@ -1,0 +1,8 @@
+{
+  pkgs,
+  perSystem,
+  ...
+}:
+pkgs.callPackage ./package.nix {
+  inherit (perSystem.self) wrapBuddy versionCheckHomeHook;
+}

--- a/packages/grok/hashes.json
+++ b/packages/grok/hashes.json
@@ -1,0 +1,8 @@
+{
+  "version": "0.1.210",
+  "hashes": {
+    "x86_64-linux": "sha256-IowYyhIcRXfB1G/qne1DiCAs0B2MKz0zG1E3RPoGx5k=",
+    "aarch64-linux": "sha256-zskTsNseNf8XGV4u6MVhPhUITkj4bdK6Jxn23sb2+8I=",
+    "aarch64-darwin": "sha256-uQZgdxkLqdZfWGf+LOzVy2pH4toDVVroQb+iMqhWiUQ="
+  }
+}

--- a/packages/grok/package.nix
+++ b/packages/grok/package.nix
@@ -1,0 +1,82 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  makeWrapper,
+  wrapBuddy,
+  versionCheckHook,
+  versionCheckHomeHook,
+}:
+
+let
+  pname = "grok";
+  versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
+  inherit (versionData) version hashes;
+
+  platformMap = {
+    x86_64-linux = "linux-x86_64";
+    aarch64-linux = "linux-aarch64";
+    aarch64-darwin = "macos-aarch64";
+  };
+
+  platform = stdenv.hostPlatform.system;
+  platformSuffix = platformMap.${platform} or (throw "Unsupported system: ${platform}");
+in
+stdenv.mkDerivation {
+  inherit pname version;
+
+  src = fetchurl {
+    url = "https://storage.googleapis.com/grok-build-public-artifacts/cli/grok-${version}-${platformSuffix}";
+    hash = hashes.${platform};
+  };
+
+  dontUnpack = true;
+
+  nativeBuildInputs = [
+    makeWrapper
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    wrapBuddy
+  ];
+
+  dontStrip = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 $src $out/libexec/grok/grok
+
+    makeWrapper $out/libexec/grok/grok $out/bin/grok \
+      --argv0 grok \
+      --add-flags --no-auto-update
+
+    makeWrapper $out/libexec/grok/grok $out/bin/agent \
+      --argv0 agent \
+      --add-flags --no-auto-update
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    versionCheckHomeHook
+  ];
+
+  passthru.category = "AI Coding Agents";
+
+  meta = with lib; {
+    description = "Grok Build, xAI's agentic coding tool";
+    homepage = "https://x.ai";
+    changelog = "https://x.ai";
+    license = licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with maintainers; [ ryoppippi ];
+    mainProgram = "grok";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "aarch64-darwin"
+    ];
+  };
+}

--- a/packages/grok/update.py
+++ b/packages/grok/update.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env nix
+#! nix shell --inputs-from .# nixpkgs#python3 --command python3
+
+"""Update script for grok package."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+
+from updater import (
+    calculate_platform_hashes,
+    fetch_text,
+    load_hashes,
+    save_hashes,
+    should_update,
+)
+
+HASHES_FILE = Path(__file__).parent / "hashes.json"
+BASE_URL = "https://storage.googleapis.com/grok-build-public-artifacts/cli"
+
+PLATFORMS = {
+    "x86_64-linux": "linux-x86_64",
+    "aarch64-linux": "linux-aarch64",
+    "aarch64-darwin": "macos-aarch64",
+}
+
+
+def main() -> None:
+    """Update the grok package."""
+    data = load_hashes(HASHES_FILE)
+    current = data["version"]
+    latest = fetch_text(f"{BASE_URL}/stable").strip()
+
+    print(f"Current: {current}, Latest: {latest}")
+
+    if not should_update(current, latest):
+        print("Already up to date")
+        return
+
+    url_template = f"{BASE_URL}/grok-{latest}-{{platform}}"
+    hashes = calculate_platform_hashes(url_template, PLATFORMS)
+
+    save_hashes(HASHES_FILE, {"version": latest, "hashes": hashes})
+    print(f"Updated to {latest}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds a new `grok` package for xAI Grok Build CLI using the public stable GCS artifacts. The package installs both `grok` and the `agent` compatibility entrypoint, and wraps them with `--no-auto-update` so updates stay managed by Nix.

The upstream stable channel currently publishes artifacts for `x86_64-linux`, `aarch64-linux`, and `aarch64-darwin`; `macos-x86_64` is not listed because the installer URL returned 404 for version `0.1.210`.

## Testing

- `nix fmt`
- `nix build --accept-flake-config path:.#grok --print-build-logs`
- `./result/bin/grok --version`
- `./result/bin/agent --version`
- `uv run packages/grok/update.py`
- `uv run ./scripts/generate-package-docs.py`
- `git diff --check`
