### PR TITLE
grok: wrap with bubblewrap to provide /bin shells on NixOS

### DIFF
--- a/packages/grok/package.nix
+++ b/packages/grok/package.nix
@@ -77,6 +77,7 @@ stdenv.mkDerivation {
     done
   ''
   + lib.optionalString (!stdenv.hostPlatform.isLinux) ''
+    install -d $out/bin
     ln -s $out/libexec/grok/grok-launcher $out/bin/grok
     ln -s $out/libexec/grok/agent-launcher $out/bin/agent
   ''

--- a/packages/grok/package.nix
+++ b/packages/grok/package.nix
@@ -6,6 +6,9 @@
   wrapBuddy,
   versionCheckHook,
   versionCheckHomeHook,
+  bashInteractive,
+  bubblewrap,
+  zsh,
 }:
 
 let
@@ -21,6 +24,14 @@ let
 
   platform = stdenv.hostPlatform.system;
   platformSuffix = platformMap.${platform} or (throw "Unsupported system: ${platform}");
+
+  bwrapFlags = lib.concatStringsSep " " [
+    "--dev-bind / /"
+    "--tmpfs /bin"
+    "--symlink ${bashInteractive}/bin/bash /bin/bash"
+    "--symlink ${zsh}/bin/zsh /bin/zsh"
+    "--symlink ${bashInteractive}/bin/sh /bin/sh"
+  ];
 in
 stdenv.mkDerivation {
   inherit pname version;
@@ -46,13 +57,30 @@ stdenv.mkDerivation {
 
     install -Dm755 $src $out/libexec/grok/grok
 
-    makeWrapper $out/libexec/grok/grok $out/bin/grok \
+    makeWrapper $out/libexec/grok/grok $out/libexec/grok/grok-launcher \
       --argv0 grok \
       --add-flags --no-auto-update
 
-    makeWrapper $out/libexec/grok/grok $out/bin/agent \
+    makeWrapper $out/libexec/grok/grok $out/libexec/grok/agent-launcher \
       --argv0 agent \
       --add-flags --no-auto-update
+  ''
+  + lib.optionalString stdenv.hostPlatform.isLinux ''
+    install -d $out/bin
+    for name in grok agent; do
+      {
+        printf '#!%s\n' '${stdenv.shell}'
+        printf 'exec %s %s -- %s/libexec/grok/%s-launcher "$@"\n' \
+          '${bubblewrap}/bin/bwrap' '${bwrapFlags}' "$out" "$name"
+      } > $out/bin/$name
+      chmod +x $out/bin/$name
+    done
+  ''
+  + lib.optionalString (!stdenv.hostPlatform.isLinux) ''
+    ln -s $out/libexec/grok/grok-launcher $out/bin/grok
+    ln -s $out/libexec/grok/agent-launcher $out/bin/agent
+  ''
+  + ''
 
     runHook postInstall
   '';

--- a/packages/grok/package.nix
+++ b/packages/grok/package.nix
@@ -25,6 +25,17 @@ let
   platform = stdenv.hostPlatform.system;
   platformSuffix = platformMap.${platform} or (throw "Unsupported system: ${platform}");
 
+  # Grok's run_command tool spawns shells via portable_pty, which execve's
+  # absolute paths like /bin/bash and /bin/zsh (derived from $SHELL, with
+  # /bin/bash as the hardcoded fallback). NixOS only ships /bin/sh, so every
+  # shell tool call fails with `Terminal error: IO Error: No such file or
+  # directory (os error 2)` before any user command runs.
+  #
+  # As a transitional workaround, wrap the Linux entry points with bubblewrap
+  # so /bin is replaced by a tmpfs containing symlinks to the matching shells
+  # from the Nix store. This wrapping should become unnecessary once upstream
+  # grok honors $SHELL (or PATH) instead of fixed /bin/* paths. Tracked in
+  # https://github.com/numtide/llm-agents.nix/issues/4912.
   bwrapFlags = lib.concatStringsSep " " [
     "--dev-bind / /"
     "--tmpfs /bin"


### PR DESCRIPTION

## Summary

Fixes #4912.

On NixOS (and other non-FHS Linux distros) the packaged `grok` binary fails every `run_command` tool call with:

```
Terminal error: IO Error: No such file or directory (os error 2)
```

The Grok CLI's `run_command` uses `portable_pty::cmdbuilder` which `execve`s `/bin/<basename($SHELL)>` directly (e.g. `/bin/bash`, `/bin/zsh`). On NixOS only `/bin/sh` exists, so the bash tool, git status, pwd, etc. all return `ENOENT` before any user command runs.

Wrap the Linux `grok` and `agent` entrypoints with `bubblewrap`: place `makeWrapper` output under `libexec/grok/{grok,agent}-launcher` and write a shell wrapper at `bin/{grok,agent}` that runs the launcher inside a bwrap namespace with `/bin` replaced by a tmpfs containing symlinks to `bashInteractive/bin/{bash,sh}` and `zsh/bin/zsh` from the Nix store. macOS keeps the previous `makeWrapper`-only behavior (symlinked into `bin/`).

The `--no-auto-update` flag and `--argv0 {grok,agent}` semantics are preserved by keeping the existing `makeWrapper` calls — they now produce the launchers that the bwrap wrapper exec's into.

After appling this patch, my grok can execute any commands.

<img width="741" height="587" alt="image" src="https://github.com/user-attachments/assets/91e278ad-d015-4408-bb7c-c38818cce4fd" />

---

Problem investigation by ClaudeCode and its response. (just FYI; [requesting by maintainer](https://x.com/ryoppippi/status/2055283405303009462))

<img width="631" height="266" alt="HIXHOD-b0AAG4v3" src="https://github.com/user-attachments/assets/38e44d8e-83b3-44a0-bb19-3b52bf3f8812" />


## Test plan

- `nix build .#grok` succeeds (versionCheckHook runs `grok --version` through the bwrap wrapper successfully)
- On NixOS, `grok --always-approve` in a tmux pane runs `pwd` and `git status` via the bash tool and returns the expected output (previously every shell tool invocation failed with the `os error 2` shown above)
- Headless mode: `grok -p "Run pwd via bash" --always-approve --output-format json` returns `/home/.../current-dir` instead of the terminal error
- [x] `nix build .#<package>` succeeds
- [x] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.

---
Assisted-by: Claude Code:claude-opus-4-7[1m]