### PR TITLE
cubic: init at 1.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -810,6 +810,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>cubic</strong> - AI code review CLI from cubic.dev - fast pre-flight review before you push</summary>
+
+- **Source**: binary
+- **License**: unfree
+- **Homepage**: https://cubic.dev
+- **Usage**: `nix run github:numtide/llm-agents.nix#cubic -- --help`
+- **Nix**: [packages/cubic/package.nix](packages/cubic/package.nix)
+
+</details>
+<details>
 <summary><strong>hunk</strong> - Terminal diff viewer for agentic changesets</summary>
 
 - **Source**: source

--- a/packages/cubic/default.nix
+++ b/packages/cubic/default.nix
@@ -1,0 +1,8 @@
+{
+  pkgs,
+  perSystem,
+  ...
+}:
+pkgs.callPackage ./package.nix {
+  inherit (perSystem.self) wrapBuddy versionCheckHomeHook;
+}

--- a/packages/cubic/hashes.json
+++ b/packages/cubic/hashes.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.5.1",
+  "hashes": {
+    "x86_64-linux": "sha256-nB3tliemNVweIPn2cClxsYN5jiHlx5Gx/yFU2FHk4hU=",
+    "x86_64-darwin": "sha256-INY5NQoNI/f5JTm+OQ1m5Fz9h7U1tsZUqY1M6vuZBgI=",
+    "aarch64-darwin": "sha256-V9akgz7q1N1YDhFfsOadi3NtiW+9KjrsaUVL2E9+mdk=",
+    "aarch64-linux": "sha256-qJ+cuDPO3s2eatqJpoUedN4oM6XZJTPqryBkwq0wUsQ="
+  }
+}

--- a/packages/cubic/package.nix
+++ b/packages/cubic/package.nix
@@ -1,0 +1,73 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  unzip,
+  wrapBuddy,
+  versionCheckHook,
+  versionCheckHomeHook,
+}:
+
+let
+  versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
+  inherit (versionData) version hashes;
+
+  platformMap = {
+    x86_64-linux = "linux-x64";
+    aarch64-linux = "linux-arm64";
+    x86_64-darwin = "darwin-x64";
+    aarch64-darwin = "darwin-arm64";
+  };
+
+  platform = stdenv.hostPlatform.system;
+  platformSuffix = platformMap.${platform} or (throw "Unsupported system: ${platform}");
+in
+stdenv.mkDerivation {
+  pname = "cubic";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://mcafvrhahbqdwfrtncql.supabase.co/storage/v1/object/public/releases/v${version}/cubic-${platformSuffix}.zip";
+    hash = hashes.${platform};
+  };
+
+  nativeBuildInputs = [ unzip ] ++ lib.optionals stdenv.hostPlatform.isLinux [ wrapBuddy ];
+
+  unpackPhase = ''
+    unzip $src
+  '';
+
+  dontStrip = true; # bun runtime embeds JS at the tail of the binary
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 cubic $out/bin/cubic
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    versionCheckHomeHook
+  ];
+  versionCheckProgramArg = "--version";
+
+  passthru.category = "Code Review";
+
+  meta = with lib; {
+    description = "AI code review CLI from cubic.dev - fast pre-flight review before you push";
+    homepage = "https://cubic.dev";
+    changelog = "https://docs.cubic.dev/ide/cli-review";
+    license = licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+    mainProgram = "cubic";
+  };
+}

--- a/packages/cubic/package.nix
+++ b/packages/cubic/package.nix
@@ -62,6 +62,7 @@ stdenv.mkDerivation {
     changelog = "https://docs.cubic.dev/ide/cli-review";
     license = licenses.unfree;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with maintainers; [ ryoppippi ];
     platforms = [
       "x86_64-linux"
       "aarch64-linux"

--- a/packages/cubic/update.py
+++ b/packages/cubic/update.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env nix
+#! nix shell --inputs-from .# nixpkgs#python3 --command python3
+
+"""Update script for cubic package."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+
+from updater import (
+    calculate_platform_hashes,
+    fetch_text,
+    load_hashes,
+    save_hashes,
+    should_update,
+)
+
+HASHES_FILE = Path(__file__).parent / "hashes.json"
+
+STORAGE_URL = (
+    "https://mcafvrhahbqdwfrtncql.supabase.co/storage/v1/object/public/releases"
+)
+
+PLATFORMS = {
+    "x86_64-linux": "linux-x64",
+    "aarch64-linux": "linux-arm64",
+    "x86_64-darwin": "darwin-x64",
+    "aarch64-darwin": "darwin-arm64",
+}
+
+
+def fetch_version() -> str:
+    """Fetch the latest version from cubic's release manifest."""
+    return fetch_text(f"{STORAGE_URL}/latest.txt").strip()
+
+
+def main() -> None:
+    """Update the cubic package."""
+    data = load_hashes(HASHES_FILE)
+    current = data["version"]
+    latest = fetch_version()
+
+    print(f"Current: {current}, Latest: {latest}")
+
+    if not should_update(current, latest):
+        print("Already up to date")
+        return
+
+    url_template = f"{STORAGE_URL}/v{latest}/cubic-{{platform}}.zip"
+    hashes = calculate_platform_hashes(url_template, PLATFORMS)
+
+    save_hashes(HASHES_FILE, {"version": latest, "hashes": hashes})
+    print(f"Updated to {latest}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds [cubic](https://cubic.dev) CLI - an AI code review tool that performs local pre-flight reviews before pushing changes.
- Pre-built bun-compiled binaries fetched from cubic's official release storage.
- Custom `update.py` since releases are hosted on Supabase storage (not GitHub) with a `latest.txt` manifest.

Categorised under **Code Review** alongside `coderabbit-cli`.

## Test plan

- [x] `nix build .#cubic` succeeds on aarch64-darwin
- [x] `./result/bin/cubic --version` reports `1.5.1`
- [x] `versionCheckHook` + `versionCheckHomeHook` pass during build
- [x] `./packages/cubic/update.py` re-fetches latest version and hashes
- [x] `./scripts/generate-package-docs.py` picks up the new package
- [x] `nix fmt` clean