### PR TITLE
omp: pin bun 1.3.14 via new bun-bin package

### DIFF
--- a/packages/bun-bin/default.nix
+++ b/packages/bun-bin/default.nix
@@ -1,0 +1,1 @@
+{ pkgs, ... }: pkgs.callPackage ./package.nix { }

--- a/packages/bun-bin/hashes.json
+++ b/packages/bun-bin/hashes.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.3.14",
+  "hashes": {
+    "aarch64-darwin": "sha256-2LliIYKK1vl6x6wKt+lYcjQa92MAHogD6CZ2UsJlJiA=",
+    "aarch64-linux": "sha256-on/7Y6gxA3WDbg1vZorhf6jY0YuIw3yCHGUzGXOhmjs=",
+    "x86_64-darwin": "sha256-PjWtb1OXGpg0v55nhuKt9ytfGSHMmpxf3gc9KXKUQHY=",
+    "x86_64-linux": "sha256-lR7iruhV8IWVruxiJSJqKY0/6oOj3NZGXAnLzN9+hI8="
+  }
+}

--- a/packages/bun-bin/package.nix
+++ b/packages/bun-bin/package.nix
@@ -1,0 +1,102 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  autoPatchelfHook,
+  unzip,
+  installShellFiles,
+  openssl,
+  cctools,
+  darwin,
+  rcodesign,
+}:
+
+let
+  versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
+  inherit (versionData) version hashes;
+
+  archName =
+    {
+      "aarch64-darwin" = "bun-darwin-aarch64";
+      "aarch64-linux" = "bun-linux-aarch64";
+      "x86_64-darwin" = "bun-darwin-x64-baseline";
+      "x86_64-linux" = "bun-linux-x64";
+    }
+    .${stdenvNoCC.hostPlatform.system}
+      or (throw "Unsupported platform for bun-bin: ${stdenvNoCC.hostPlatform.system}");
+in
+stdenvNoCC.mkDerivation {
+  pname = "bun-bin";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://github.com/oven-sh/bun/releases/download/bun-v${version}/${archName}.zip";
+    hash =
+      hashes.${stdenvNoCC.hostPlatform.system}
+        or (throw "Missing bun hash for ${stdenvNoCC.hostPlatform.system}");
+  };
+
+  # Darwin zips contain a subdirectory; Linux ones extract flat.
+  sourceRoot =
+    {
+      "aarch64-darwin" = archName;
+      "x86_64-darwin" = archName;
+    }
+    .${stdenvNoCC.hostPlatform.system} or null;
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    unzip
+    installShellFiles
+  ]
+  ++ lib.optionals stdenvNoCC.hostPlatform.isLinux [ autoPatchelfHook ];
+
+  buildInputs = [ openssl ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm 755 ./bun $out/bin/bun
+    ln -s $out/bin/bun $out/bin/bunx
+    runHook postInstall
+  '';
+
+  postPhases = [ "postPatchelf" ];
+  postPatchelf =
+    lib.optionalString stdenvNoCC.hostPlatform.isDarwin ''
+      '${lib.getExe' cctools "${cctools.targetPrefix}install_name_tool"}' $out/bin/bun \
+        -change /usr/lib/libicucore.A.dylib '${lib.getLib darwin.ICU}/lib/libicucore.A.dylib'
+      '${lib.getExe rcodesign}' sign --code-signature-flags linker-signed $out/bin/bun
+    ''
+    +
+      lib.optionalString
+        (
+          stdenvNoCC.buildPlatform.canExecute stdenvNoCC.hostPlatform
+          && !(stdenvNoCC.hostPlatform.isDarwin && stdenvNoCC.hostPlatform.isx86_64)
+        )
+        ''
+          installShellCompletion --cmd bun \
+            --bash <(SHELL="bash" $out/bin/bun completions) \
+            --zsh <(SHELL="zsh" $out/bin/bun completions) \
+            --fish <(SHELL="fish" $out/bin/bun completions)
+        '';
+
+  passthru.hideFromDocs = true;
+
+  meta = {
+    description = "Latest Bun runtime (prebuilt binary) for packages that need a newer version than nixpkgs ships";
+    homepage = "https://bun.sh";
+    changelog = "https://bun.sh/blog/bun-v${version}";
+    license = with lib.licenses; [
+      mit
+      lgpl21Only
+    ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    mainProgram = "bun";
+    platforms = builtins.attrNames hashes;
+    broken = stdenvNoCC.hostPlatform.isMusl;
+  };
+}

--- a/packages/bun-bin/update.py
+++ b/packages/bun-bin/update.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env nix
+#! nix shell --inputs-from .# nixpkgs#python3 --command python3
+
+"""Update script for bun-bin package.
+
+Fetches the latest stable Bun release from GitHub and updates hashes.json.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+
+from updater import (
+    calculate_platform_hashes,
+    fetch_github_latest_release,
+    load_hashes,
+    save_hashes,
+    should_update,
+)
+
+HASHES_FILE = Path(__file__).parent / "hashes.json"
+
+# Maps nix platform to bun archive name component
+PLATFORMS = {
+    "aarch64-darwin": "darwin-aarch64",
+    "aarch64-linux": "linux-aarch64",
+    "x86_64-darwin": "darwin-x64-baseline",
+    "x86_64-linux": "linux-x64",
+}
+
+URL_TEMPLATE = (
+    "https://github.com/oven-sh/bun/releases/download/bun-v{version}/bun-{platform}.zip"
+)
+
+
+def main() -> None:
+    """Update the bun-bin package."""
+    data = load_hashes(HASHES_FILE)
+    current = data["version"]
+
+    print(f"Current: {current}")
+
+    latest = fetch_github_latest_release("oven-sh", "bun")
+    # Bun tags are "bun-v1.2.3"
+    latest = latest.removeprefix("bun-v")
+    print(f"Latest: {latest}")
+
+    if not should_update(current, latest):
+        print("Already up to date")
+        return
+
+    hashes = calculate_platform_hashes(URL_TEMPLATE, PLATFORMS, version=latest)
+    for plat, h in sorted(hashes.items()):
+        print(f"  {plat}: {h}")
+
+    save_hashes(HASHES_FILE, {"version": latest, "hashes": hashes})
+    print(f"Updated to {latest}")
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/omp/default.nix
+++ b/packages/omp/default.nix
@@ -1,9 +1,13 @@
 {
   pkgs,
   flake,
+  perSystem,
   ...
 }:
 let
   bun2nix = (pkgs.extend flake.inputs.bun2nix.overlays.default).bun2nix;
 in
-pkgs.callPackage ./package.nix { inherit bun2nix; }
+pkgs.callPackage ./package.nix {
+  inherit bun2nix;
+  bun = perSystem.self.bun-bin;
+}


### PR DESCRIPTION
omp >= 15 requires bun >= 1.3.14 but nixpkgs still ships 1.3.13, causing a startup crash: 'Bun runtime must be >= 1.3.14'.

Add a bun-bin package (like go-bin) that tracks the latest bun release independently of nixpkgs, with its own update script. omp now uses bun-bin instead of nixpkgs bun.

Closes: #4931
Ref: NixOS/nixpkgs#519796

## Summary

<!-- Briefly describe what this PR does -->

## Test plan

<!-- How did you test this change? -->

- [ ] `nix build .#<package>` succeeds
- [ ] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
