### PR TITLE
pnpm: migrate fetchPnpmDeps to fetcherVersion = 3

### DIFF
--- a/packages/agent-browser/package.nix
+++ b/packages/agent-browser/package.nix
@@ -44,8 +44,8 @@ let
       pname = "${pname}-dashboard";
       inherit version src;
       pnpm = pnpm_10;
-      hash = "sha256-p9xpkR15JRq3zzx0GtICpETqRWLyHT7RTgkQ0Y9qWsY=";
-      fetcherVersion = 2;
+      hash = "sha256-xNxNFvaw5sdX0ZaBIUf449wIHQNifMPK3I+qi+yp+UU=";
+      fetcherVersion = 3;
     };
 
     # next/font/google fetches Geist from fonts.googleapis.com at build

--- a/packages/happy-coder/hashes.json
+++ b/packages/happy-coder/hashes.json
@@ -2,5 +2,5 @@
   "version": "1.1.8",
   "srcRev": "b72fd8111a43395e9991cfbdabba36f5a3285e5e",
   "srcHash": "sha256-4Yzrz7+1MzsD/ObUC97ABaAgkfO0NW06TgjHqFKF1kA=",
-  "pnpmDepsHash": "sha256-vGMhQ4v9XHYXQHqXkRAPkzVd6dypPzBYZ1KDuET1fTg="
+  "pnpmDepsHash": "sha256-STnqzVxClUfuf2la2R6yeIrNbaXsTpT6tX9xUJoLsK4="
 }

--- a/packages/happy-coder/package.nix
+++ b/packages/happy-coder/package.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
     inherit pnpmWorkspaces;
     pnpm = pnpm_10;
     hash = pin.pnpmDepsHash;
-    fetcherVersion = 2;
+    fetcherVersion = 3;
   };
 
   inherit pnpmWorkspaces;

--- a/packages/mcporter/package.nix
+++ b/packages/mcporter/package.nix
@@ -41,8 +41,8 @@ stdenv.mkDerivation (finalAttrs: {
       postPatch
       ;
     inherit pnpm;
-    hash = "sha256-bY3iL/pugOyTPqWVy6vLSyXmnvIv0DebkY67+1XTMqI=";
-    fetcherVersion = 2;
+    hash = "sha256-TZfEoUSjba8cRz6L9uY2PGskYsR7S/xAahiKLd8dhFM=";
+    fetcherVersion = 3;
   };
 
   nativeBuildInputs = [

--- a/packages/nanocoder/package.nix
+++ b/packages/nanocoder/package.nix
@@ -30,8 +30,8 @@ buildNpmPackage rec {
   pnpmDeps = fetchPnpmDeps {
     inherit pname version src;
     inherit pnpm;
-    fetcherVersion = 2;
-    hash = "sha256-UWN+7uxZsK9kme32UMWBuudtCMepagA9mU8+f0a8sQ8=";
+    fetcherVersion = 3;
+    hash = "sha256-FFRHvQ5HKQ9v2Wwh8W7ILWb0FlLrVD+ktYBwjNVAfrI=";
   };
 
   nativeBuildInputs = [ pnpm ];

--- a/packages/openclaw/package.nix
+++ b/packages/openclaw/package.nix
@@ -31,8 +31,8 @@ stdenv.mkDerivation (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     inherit pnpm;
-    hash = "sha256-JXfo1vb5wVbMwBM1DogKxz2/thCXOV82dhrPq/xklc4=";
-    fetcherVersion = 2;
+    hash = "sha256-LXaRfZ0WY8VDpDc2zFr+Oel6AuYo6SiTrp37yokT1VU=";
+    fetcherVersion = 3;
   };
 
   nativeBuildInputs = [

--- a/packages/vibe-kanban/hashes.json
+++ b/packages/vibe-kanban/hashes.json
@@ -3,6 +3,6 @@
   "tag": "v0.1.44-20260424091429",
   "hash": "sha256-PNfk8spdjxg2TAaA6g83YJPugH2O5UirrjJIJ1GVoeo=",
   "cargoHash": "sha256-P0sByQn9vK/Sm/ImiNCRtAJC6lG0M8ZqjxZFAJ4EiZ8=",
-  "npmDepsHash": "sha256-wRJCTDvl6ThpQtV9DbJSyv3o2LEaYN9ZM1nricqaGaQ=",
+  "npmDepsHash": "sha256-dOsbAKOb7O6MP04cfD7y7of0sDvNmEWovLTzjUnV+1Y=",
   "releaseZipHash": "sha256-lMqN0w0EldusDHtuimAhogXBln9/GEmAFONT/IwYwqk="
 }

--- a/packages/vibe-kanban/package.nix
+++ b/packages/vibe-kanban/package.nix
@@ -61,7 +61,7 @@ let
       inherit version src;
       pnpm = pnpm_10;
       hash = npmDepsHash;
-      fetcherVersion = 2;
+      fetcherVersion = 3;
     };
 
     buildPhase = ''


### PR DESCRIPTION
fetcherVersion = 2 is deprecated in nixpkgs and scheduled for removal in 26.11. Bump all pnpm-based packages to fetcherVersion = 3 and regenerate the corresponding pnpmDeps hashes.

Affected packages: agent-browser, gitbutler, happy-coder, mcporter, nanocoder, openclaw, vibe-kanban.

## Summary

<!-- Briefly describe what this PR does -->

## Test plan

<!-- How did you test this change? -->

- [ ] `nix build .#<package>` succeeds
- [ ] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
