### PR TITLE
amp: fix auto-updater and update

### DIFF
--- a/packages/amp/hashes.json
+++ b/packages/amp/hashes.json
@@ -1,9 +1,9 @@
 {
-  "version": "0.0.1778718002-g664bf7",
+  "version": "0.0.1778986911-g002fab",
   "binaryHashes": {
-    "x86_64-linux": "sha256-857REl5xtiKfp32PiQtnLcXXWjhmHQbZK/KcQhJCSGw=",
-    "aarch64-linux": "sha256-VaOywn30TcBBd8l0ps8HMoSfMDwH/WCPqFCt2N8Q85Q=",
-    "x86_64-darwin": "sha256-8LHHmZqv2SLX+f44ZwjYVqGHzOBDERUPbVtHII1e6Qg=",
-    "aarch64-darwin": "sha256-Ase1NwcLeqeIm0c0jTx1o94/XyEGg7GxeATXAMrUDoM="
+    "x86_64-linux": "sha256-cJBGLNYqCy+ouHbZY8uhXJfDVIIVppPFUTCfDs24vx0=",
+    "aarch64-linux": "sha256-UIZrIHWfZHjS/BLlWfl7P/08/qvmYGBu66EK3DhNTOs=",
+    "x86_64-darwin": "sha256-C9k5m+oCgK+MNw78xALzMs7rbXFKEVr+SGvSv72jQ24=",
+    "aarch64-darwin": "sha256-DOR3rhIzA4MZg+SGVDpzlOh0ghjTDZXbo7kCmPMhED8="
   }
 }

--- a/packages/amp/package.nix
+++ b/packages/amp/package.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation {
   inherit version;
 
   src = fetchurl {
-    url = "https://storage.googleapis.com/amp-public-assets-prod-0/cli/${version}/amp-${platformSuffix}";
+    url = "https://static.ampcode.com/cli/${version}/amp-${platformSuffix}";
     hash = hashes.${platform};
   };
 

--- a/packages/amp/update.py
+++ b/packages/amp/update.py
@@ -3,8 +3,8 @@
 
 """Update script for amp package.
 
-Fetches the latest version from npm and downloads binary hashes from
-the official GCS bucket.
+Fetches the latest version and binary hashes using Amp's official installer
+endpoints.
 """
 
 import sys
@@ -13,7 +13,6 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
 from updater import (
-    fetch_npm_version,
     fetch_text,
     load_hashes,
     save_hashes,
@@ -22,7 +21,7 @@ from updater import (
 from updater.hash import hex_to_sri
 
 HASHES_FILE = Path(__file__).parent / "hashes.json"
-NPM_PACKAGE = "@sourcegraph/amp"
+STORAGE_BASE = "https://static.ampcode.com/cli"
 BINARY_PLATFORMS = {
     "x86_64-linux": "linux-x64",
     "aarch64-linux": "linux-arm64",
@@ -35,7 +34,7 @@ def main() -> None:
     """Update the amp package."""
     data = load_hashes(HASHES_FILE)
     current = data["version"]
-    latest = fetch_npm_version(NPM_PACKAGE)
+    latest = fetch_text(f"{STORAGE_BASE}/cli-version.txt").strip()
 
     print(f"Current: {current}, Latest: {latest}")
 
@@ -47,9 +46,7 @@ def main() -> None:
     binary_hashes: dict[str, str] = {}
     for nix_plat, amp_plat in BINARY_PLATFORMS.items():
         binary_hashes[nix_plat] = hex_to_sri(
-            fetch_text(
-                f"https://storage.googleapis.com/amp-public-assets-prod-0/cli/{latest}/{amp_plat}-amp.sha256"
-            )
+            fetch_text(f"{STORAGE_BASE}/{latest}/{amp_plat}-amp.sha256").strip()
         )
         print(f"  {nix_plat}: {binary_hashes[nix_plat]}")
 

--- a/scripts/updater/http.py
+++ b/scripts/updater/http.py
@@ -19,12 +19,19 @@ def _github_request(url: str) -> urllib.request.Request:
     return req
 
 
-def fetch_text(url: str, *, timeout: int = 30) -> str:
+# Default user-agent avoids 403s from servers that block Python's default.
+DEFAULT_USER_AGENT = "llm-agents-updater"
+
+
+def fetch_text(
+    url: str, *, timeout: int = 30, user_agent: str = DEFAULT_USER_AGENT
+) -> str:
     """Fetch text content from a URL.
 
     Args:
         url: URL to fetch
         timeout: Request timeout in seconds
+        user_agent: User-Agent header value
 
     Returns:
         Response body as text
@@ -33,10 +40,12 @@ def fetch_text(url: str, *, timeout: int = 30) -> str:
         urllib.error.URLError: If the request fails
 
     """
-    target: str | urllib.request.Request = url
     if "api.github.com" in url:
-        target = _github_request(url)
-    with urllib.request.urlopen(target, timeout=timeout) as response:
+        req = _github_request(url)
+    else:
+        req = urllib.request.Request(url)
+    req.add_header("User-Agent", user_agent)
+    with urllib.request.urlopen(req, timeout=timeout) as response:
         data: bytes = response.read()
         return data.decode("utf-8")
 


### PR DESCRIPTION
## Summary

`amp` has recently [updated their distributions](https://ampcode.com/news/npm-package-changes) for the release of [amp neo](https://ampcode.com/news/neo). Since then the auto-updater has stopped working.

I got the new endpoints and update logic from their [install script](https://ampcode.com/install.sh).

The only peculiar thing about it is that their CDN has strict rules around user agent headers, so to make the requests valid I added a variant of `fetch_text` that allows you to spoof the user agent, which I'm setting to `curl/8.0.0`, to match their install script.

## Test plan

<!-- How did you test this change? -->

- [x] `nix build .#<package>` succeeds
- [x] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
