### PR TITLE
hermes-agent: 2026.5.7 -> 2026.5.16

### DIFF
--- a/packages/hermes-agent/package.nix
+++ b/packages/hermes-agent/package.nix
@@ -122,13 +122,13 @@ let
     };
   };
 
-  version = "2026.5.7";
+  version = "2026.5.16";
 
   src = fetchFromGitHub {
     owner = "NousResearch";
     repo = "hermes-agent";
     rev = "v${version}";
-    hash = "sha256-YQQUEDUim2CiYpL3uG7Wi1fWPsT2wtIqoBeJuAj9hUk=";
+    hash = "sha256-d9qhrTy45Q5UsmjapqMHOVi9e+gR9zE8Nq9Z0wObLmc=";
   };
 
   # `hermes --tui` runs a compiled Ink/React app from ui-tui/ that the wheel
@@ -138,7 +138,7 @@ let
     pname = "hermes-tui";
     inherit version;
     src = "${src}/ui-tui";
-    npmDepsHash = "sha256-MLcLhjTF6dgdvNBtJWzo8Nh19eNh/ZitD2b07nm61Tc=";
+    npmDepsHash = "sha256-9r1EYQ600gNXOnNXwakorpEk7hS/FPxZVbB2JksrhYs=";
 
     installPhase = ''
       runHook preInstall
@@ -186,11 +186,16 @@ let
       rich
       tenacity
       pyyaml
+      ruamel-yaml
       requests
       jinja2
       pydantic
       # Interactive CLI
       prompt-toolkit
+      # Cron scheduler
+      croniter
+      # Process / PID management
+      psutil
       # MCP
       mcp
       # Tools
@@ -291,7 +296,9 @@ python3.pkgs.buildPythonApplication {
   ];
 
   pythonRelaxDeps = [
+    "openai"
     "tenacity"
+    "ruamel.yaml"
     "requests"
     "pydantic"
     "firecrawl-py"


### PR DESCRIPTION

## Summary

Closes #4951. v2026.5.16 was tagged on 2026-05-16 and includes the xAI Grok OAuth provider (announced 2026-05-15 at https://x.ai/news/grok-hermes — provider id `xai-oauth`, default model `grok-4.3`, no `XAI_API_KEY` required, OAuth tokens auto-refresh).

The automatic update PR #4951 ran into three dep-pin failures from upstream pyproject changes between v2026.5.7 and v2026.5.16:

```
hermes-agent>   - openai==2.24.0 not satisfied by version 2.31.0
hermes-agent>   - ruamel-yaml not installed
hermes-agent>   - psutil not installed
```

Add `openai` and `ruamel.yaml` to `pythonRelaxDeps` (the existing `tenacity` / `requests` / `pydantic` / `pyjwt` entries already cover the unrelated pin deltas from nixpkgs), and add the three new core deps `ruamel-yaml`, `croniter`, `psutil` to `hermesDeps`. nixpkgs satisfies the rest of the v2026.5.16 pin set (`python-dotenv 1.2.1`, `fire 0.7.1`, `httpx 0.28.1`, `rich 14.3.3`, `pyyaml 6.0.3`, `jinja2 3.1.6`, `pydantic 2.12.5`, `prompt-toolkit 3.0.52`, `croniter 6.0.0`, `pyjwt 2.12.1`, `psutil 7.2.2`) at the exact pinned versions.

## Test plan

- `nix build .#hermes-agent` succeeds (versionCheckHook runs `hermes --version` and matches `Hermes Agent v0.14.0 (2026.5.16)`)
- Deployed to a NixOS host via home-manager; `hermes auth add xai-oauth` completes the loopback PKCE flow, populates `~/.hermes/auth.json` under `providers.xai-oauth`, and `hermes auth list` shows the credential alongside `openai-codex`. `hermes fallback add` accepts `xai-oauth` + `grok-4.3` as a fallback entry, and primary-429 → fallback chat completion succeeds end-to-end (`grok-4.3` answers when the primary `openai-codex` returns `usage_limit_reached`).
- [x] `nix build .#<package>` succeeds
- [x] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.

---
Assisted-by: Claude Code:claude-opus-4-7[1m]