### PR TITLE
ccusage: remove deprecated compatibility packages

### DIFF
--- a/packages/ccusage-amp/default.nix
+++ b/packages/ccusage-amp/default.nix
@@ -1,9 +1,0 @@
-{
-  pkgs,
-  perSystem,
-  ...
-}:
-pkgs.lib.warnOnInstantiate "'ccusage-amp' has been consolidated into 'ccusage'. Please update your references." perSystem.self.ccusage
-// {
-  passthru.hideFromDocs = true;
-}

--- a/packages/ccusage-codex/default.nix
+++ b/packages/ccusage-codex/default.nix
@@ -1,9 +1,0 @@
-{
-  pkgs,
-  perSystem,
-  ...
-}:
-pkgs.lib.warnOnInstantiate "'ccusage-codex' has been consolidated into 'ccusage'. Please update your references." perSystem.self.ccusage
-// {
-  passthru.hideFromDocs = true;
-}

--- a/packages/ccusage-opencode/default.nix
+++ b/packages/ccusage-opencode/default.nix
@@ -1,9 +1,0 @@
-{
-  pkgs,
-  perSystem,
-  ...
-}:
-pkgs.lib.warnOnInstantiate "'ccusage-opencode' has been consolidated into 'ccusage'. Please update your references." perSystem.self.ccusage
-// {
-  passthru.hideFromDocs = true;
-}

--- a/packages/ccusage-pi/default.nix
+++ b/packages/ccusage-pi/default.nix
@@ -1,9 +1,0 @@
-{
-  pkgs,
-  perSystem,
-  ...
-}:
-pkgs.lib.warnOnInstantiate "'ccusage-pi' has been consolidated into 'ccusage'. Please update your references." perSystem.self.ccusage
-// {
-  passthru.hideFromDocs = true;
-}


### PR DESCRIPTION
Remove the deprecated ccusage compatibility package outputs: ccusage-amp, ccusage-codex, ccusage-opencode, and ccusage-pi. Only the unified ccusage package remains supported.

The generated README already hid these aliases, so regenerating package docs leaves README.md unchanged.

Validation:
- nix fmt
- uv run --no-project ./scripts/generate-package-docs.py
- nix eval --json .#packages.aarch64-darwin.ccusage.meta.mainProgram
- nix eval --json .#packages.aarch64-darwin.ccusage-amp (expected missing attribute)
