### PR TITLE
ccusage: switch runtime back to bun and bypass cli.js launcher

### DIFF
--- a/packages/ccusage/package.nix
+++ b/packages/ccusage/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchzip,
   makeWrapper,
-  nodejs,
+  bun,
   versionCheckHook,
   versionCheckHomeHook,
 }:
@@ -26,8 +26,14 @@ stdenv.mkDerivation rec {
 
     cp -r dist $out/lib
 
-    makeWrapper ${nodejs}/bin/node $out/bin/ccusage \
-      --add-flags $out/lib/cli.js
+    # ccusage 19+ ships a `cli.js` launcher that re-execs into either
+    # `main.bun.js` (under Bun) or `main.node.js` (under Node). Skip
+    # that indirection and point the wrapper at `main.bun.js` to run
+    # the intended Bun entrypoint directly.
+    # For ccusage <=18 the entry point was `index.js`; restore that if
+    # the package is ever downgraded.
+    makeWrapper ${bun}/bin/bun $out/bin/ccusage \
+      --add-flags $out/lib/main.bun.js
 
     runHook postInstall
   '';


### PR DESCRIPTION
## Summary

ccusage 19.0.x introduced a `dist/cli.js` shim that dispatches to either `main.bun.js` (under Bun) or `main.node.js` (under Node). The split signals that upstream is treating Bun as a first-class runtime again and may add Bun-specific code paths to `main.bun.js`, so move ccusage back onto Bun.

- Re-add the `bun` input that 3ecccf94 removed and drop `nodejs`.
- Wrap `bun` against `main.bun.js` directly to skip the `cli.js` launcher's runtime-detection fork.
- Comment the install phase explaining the 19+ layout and noting that ccusage ≤18 used `index.js` as the entry point, in case the package is ever downgraded.

### Trade-off

Bun was removed in 3ecccf94 to avoid `Illegal instruction` (SIGILL) on pre-Haswell (no AVX2) CPUs — see numtide/llm-agents.nix#3319 (Xeon E3-1220 V2 / Ivy Bridge). That regression is accepted here in exchange for aligning with the runtime upstream is now targeting. If users on pre-2013 CPUs report the SIGILL again we can revisit (e.g. ship a `ccusage-node` variant).

## Test plan

- [x] `nix build --accept-flake-config .#ccusage`
- [x] `./result/bin/ccusage --version` → `19.0.2`
- [x] `cat ./result/bin/ccusage` shows `exec ".../bun-1.3.13/bin/bun" .../lib/main.bun.js "$@"`
- [x] `nix fmt`